### PR TITLE
WWDC 2018：关于iOS 12、iPad Pro、新MacBook及更多产品的所有预测

### DIFF
--- a/TODO1/wwdc-2018-rumors-ios-12-new-macbook-air-ipad-pro-homepod.md
+++ b/TODO1/wwdc-2018-rumors-ios-12-new-macbook-air-ipad-pro-homepod.md
@@ -3,43 +3,43 @@
 > * 译文出自：[掘金翻译计划](https://github.com/xitu/gold-miner)
 > * 本文永久链接：[https://github.com/xitu/gold-miner/blob/master/TODO1/wwdc-2018-rumors-ios-12-new-macbook-air-ipad-pro-homepod.md](https://github.com/xitu/gold-miner/blob/master/TODO1/wwdc-2018-rumors-ios-12-new-macbook-air-ipad-pro-homepod.md)
 > * 译者：[Dandy Xu](https://github.com/dandyxu)
-> * 校对者：
+> * 校对者：[shisaq](https://github.com/shisaq)
 
-# WWDC 2018：关于iOS 12、iPad Pro、新MacBooks或者更多产品的所有预测
+# WWDC 2018：关于iOS 12、iPad Pro、新MacBooks及更多产品的所有预测
 
 ## 当蒂姆库克(Tim Cook)在6月4日走进圣何塞(San Jose)的发布会现场时将会发生什么事情？(译者注：圣何塞(San Jose)是美国加州的第三大城市)
 
 我们距离[苹果公司](/apple/)的下一个正式发布会只有2周的时间了，我们通常可以在发布会上一窥该公司的未来。
 
-苹果公司一年一度的[世界开发者大会](https://www.cnet.com/wwdc)提供了关于下一代操作系统和软件应用的线索和方向，它们为该公司的[iPhones](/products/apple-iphone-x/review/)、[iPads](/products/apple-ipad-2018-9-7-inch/review/)、Macs、手表、[HomePod](/products/apple-homepod/review/)音响和 [苹果电视](/products/apple-tv-4k/review/)提供动力。今年的发布会于6月4日至8日，在美国加州圣何塞市的McEnery Convention Center举行，同时也给第三方开发者们提供了一个和苹果管理层、工程师以及产品设计人员沟通交流的机会。
+苹果公司一年一度的[世界开发者大会](https://www.cnet.com/wwdc)提供了关于下一代操作系统和软件应用的线索和方向，它们为该公司的[iPhone](https://www.cnet.com/products/apple-iphone-x/review/)、[iPad](https://www.cnet.com/products/apple-ipad-2018-9-7-inch/review/)、Macs、手表、[HomePod](https://www.cnet.com/products/apple-homepod/review/)音响和 [苹果电视](https://www.cnet.com/products/apple-tv-4k/review/)提供动力。今年的发布会于6月4日至8日，在美国加州圣何塞市的McEnery Convention Center举行，同时也给第三方开发者们提供了一个和苹果管理层、工程师以及产品设计人员沟通交流的机会。
 
-[WWDC](/wwdc/)中极有可能揭露将在今年内实现的针对操作系统、应用、服务以及软件框架的更新升级。但是，苹果有时也会用来发布一些新的硬件。在我们进行更深层次的软件预计分析之前，我们先来探讨一下可能会发布哪些新的硬件。
+[WWDC](https://www.cnet.com/wwdc/)中极有可能揭露将在今年内实现的针对操作系统、应用、服务以及软件框架的更新升级。但是，苹果有时也会用来发布一些新的硬件。在我们进行更深层次的软件预计分析之前，我们先来探讨一下可能会发布哪些新的硬件。
 
-## 可能会发布新的iPad Pros，MacBooks或者更多的硬件
+## 可能会发布新的iPad Pro、MacBook及更多的硬件
 
-当苹果公司CEO蒂姆库克(Tim Cook)在6月4日站在发布会舞台上时，不要期望能够看到新的高端iPhones或者新版本的Mac Pro。[iPhone X](/products/apple-iphone-x/review/)、[iPhone 8](/products/apple-iphone-8-review/)和[iPhone 8 Plus](/products/apple-iphone-8-plus/review/)通常在9月份发布，同时苹果也已经确认了[新的Mac Pro将于2019年发布](/news/the-new-mac-pro-is-coming-in-2019/)。同样的，[HomePod](/products/apple-homepod/review/)音响和[入门级别的iPad](/products/apple-ipad-2018-9-7-inch/review/)也分别于2月和3月刚刚全新发布。
+当苹果公司CEO蒂姆库克(Tim Cook)在6月4日站在发布会舞台上时，不要期望能够看到新的高端iPhones或者新版本的Mac Pro。[iPhone X](https://www.cnet.com/products/apple-iphone-x/review/)、[iPhone 8](https://www.cnet.com/products/apple-iphone-8-review/)和[iPhone 8 Plus](https://www.cnet.com/products/apple-iphone-8-plus/review/)已经如期在去年9月份发布了，同时苹果也已经确认了[新的Mac Pro将于2019年发布](https://www.cnet.com/news/the-new-mac-pro-is-coming-in-2019/)。同样的，[HomePod](https://www.cnet.com/products/apple-homepod/review/)音响和[入门级别的iPad](https://www.cnet.com/products/apple-ipad-2018-9-7-inch/review/)也分别于2月和3月刚刚全新发布。
 
 但这里有4个产品类别，极有可能在6月份进行发布：
 
-**MacBooks and iMacs:** 在去年的WWDC中，苹果几乎将整条笔记本和台式机的产品线进行了更新。现在，一年过去了，将全部产品升级到最新的[第8代Intel处理器](/news/kaby-lake-coffee-lake-and-beyond-what-we-know-about-the-next-intel-chips/)，尽管有些枯燥，但确实是最简单的升级做法。但是否需要更大规模的设计检查 - 例如重新思考[蝴蝶键盘的问题](/news/apple-macbook-keyboard-issue-prompts-lawsuit/)和在[MacBook Pro笔记本](/products/apple-macbook-pro-with-touch-bar-15-inch-2017/review/)上[仍然存在争议的Touch Bar功能](/news/apple-macbook-pro-touch-problems-commentary/)，仍然有待观察。同样的问题也适用于MacBook Air，一直有预测说该系列将会迎来新的型号。
+**MacBooks and iMacs:** 在去年的WWDC中，苹果几乎将整条笔记本和台式机的产品线进行了更新。现在，一年过去了，将全部产品升级到最新的[第8代Intel处理器](https://www.cnet.com/news/kaby-lake-coffee-lake-and-beyond-what-we-know-about-the-next-intel-chips/)，尽管有些枯燥，但确实是最简单的升级做法。但是否需要更大规模的设计改革 - 例如重新思考[蝴蝶键盘的问题](https://www.cnet.com/news/apple-macbook-keyboard-issue-prompts-lawsuit/)和在[MacBook Pro笔记本](https://www.cnet.com/products/apple-macbook-pro-with-touch-bar-15-inch-2017/review/)上[仍然存在争议的Touch Bar功能](https://www.cnet.com/news/apple-macbook-pro-touch-problems-commentary/)，仍然有待观察。同样的问题也适用于MacBook Air，一直有预测说该系列将会迎来新的型号。
 
-阅读：[2018 MacBook Air：所有关于规格、价格以及发布时间的预测](/news/2018-macbook-air-all-the-rumors-on-specs-price-release-date/)
+阅读：[2018 MacBook Air：所有关于规格、价格以及发布时间的预测](https://www.cnet.com/news/2018-macbook-air-all-the-rumors-on-specs-price-release-date/)
 
 ![ipad-pro-12-34](https://cnet1.cbsistatic.com/img/pLk32huKrWmXsXUmt-XHiJupsbM=/970x0/2017/07/17/33e09a24-eba2-4e4b-890e-0f6faa1da6e8/ipad-pro-12-34.jpg)
 
 Sarah Tew/CNET
 
-**iPad Pros:** 苹果刚刚在3月给[iPad Pro](/products/apple-ipad-pro-10-5-inch-2017/review/)产品线引入了一个重要的功能，就是让新的[入门级iPad](/products/apple-ipad-2018-9-7-inch/review/)首次可以兼容Pencil stylus。人们普遍认为这也许将使价格昂贵的iPad Pro能够也采用iPhone X风格的设计：去掉home键，同时添加Face ID。
+**iPad Pros:** 苹果刚刚在3月给[iPad Pro](/products/apple-ipad-pro-10-5-inch-2017/review/)产品线引入了一个重要的功能，就是让新的[入门级iPad](https://www.cnet.com/products/apple-ipad-2018-9-7-inch/review/)兼容手写笔。人们认为这种举措将使价格更高的iPad Pro可以向iPhone X的风格迈进：去掉home键，同时添加Face ID。
 
-阅读：[iPad Pro 2018：所有关于规格、价格以及发布时间的预测](/news/ipad-pro-2018-all-the-rumors-on-specs-price-release-date/)
+阅读：[iPad Pro 2018：所有关于规格、价格以及发布时间的预测](https://www.cnet.com/news/ipad-pro-2018-all-the-rumors-on-specs-price-release-date/)
 
-**iPhone SE 2:** 如我们之前说过的，iPhone的大升级通常都在9月份。但一直有预测说[iPhone SE](/products/apple-iphone-se-review/)，首次在2016年3月亮相的入门级iPhone，应该进行某些部分的升级。是否采用全屏幕的iPhone X设计(看起来不太可能)或者只是基于现有模块的规格升级(更有可能)，这些都是未知的。
+**iPhone SE 2:** 如我们之前说过的，iPhone的大升级通常都在9月份。但一直有预测说[iPhone SE](https://www.cnet.com/products/apple-iphone-se-review/) - 即首次在2016年3月亮相的入门级iPhone，或多或少是该升级了。是否采用全屏幕的iPhone X设计(看起来不太可能)或者只是基于现有模块的规格升级(更有可能)，这些都是未知的。
 
-阅读：[iPhone SE 2：预测的规格、价格、发布时间](/news/iphone-se-2-launch-date-specs-price-release-date-rumors-notch/)
+阅读：[iPhone SE 2：预测的规格、价格、发布时间](https://www.cnet.com/news/iphone-se-2-launch-date-specs-price-release-date-rumors-notch/)
 
-**Apple AirPower:** 当Phil Schiller，苹果公司的全球市场高级副总裁，在2017年9月介绍这个和iPhone X搭配使用的，多设备的充电设备时，他说这将在"明年"推出。所以，直到2019年的1月1日，你都不能说它推出“晚”了，有一种假设是苹果公司希望在这个产品发布一周年之前，将它放上货架出售。WWDC将会是一个绝佳的机会去宣布它的价格和发售日期 - 也许我们还能看到和AirPower兼容的AirPods收纳盒。
+**Apple AirPower:** 苹果公司的全球市场高级副总裁Phil Schiller在2017年9月介绍这个和iPhone X搭配使用的，多设备的充电设备时，他说这将在"明年"推出。所以，直到2019年的1月1日，你都不能说它推出“晚”了，有一种假设是苹果公司希望在这个产品发布一周年之前，将它放上货架出售。WWDC将会是一个绝佳的机会去宣布它的价格和发售日期 - 也许我们还能看到和AirPower兼容的AirPods收纳盒。
 
-阅读：[AirPower: 我们所知道的苹果无线充电板](/news/apple-airpower-wireless-charger-everything-we-know/)
+阅读：[AirPower: 我们所知道的苹果无线充电板](https://www.cnet.com/news/apple-airpower-wireless-charger-everything-we-know/)
 
 ![airpower-charging](https://cnet3.cbsistatic.com/img/ncNN2P2MqPIxuYdY7jRaGHHUkzM=/970x0/2017/09/12/02937a84-4f0a-4611-8af2-4a5764b95055/screen-shot-2017-09-12-at-2-44-50-pm.png)
 
@@ -47,13 +47,13 @@ AirPower早在2017年的9月份就发布了，但到现在还没有发售。
 
 截图来自Alexandra Able/CNET
 
-**其他我们不期望在6月4日出现的产品:** 对于其他的苹果硬件，恐怕它们都需要一个长期的过程。不要期望会看到新的苹果手表，苹果电视盒，[第二代的AirPods](/news/apple-airpods-2-wireless-charging-things-we-expect/)或者[小型HomePod音响](/news/homepod-slow-sales-homepod-mini-homepod-price-cut/)。也许苹果会花一些时间去提及[AR Kit](/pictures/best-arkit-apps/) - 它是一个软件工具集，将增强现实带进iOS - 同时[Mac里的虚拟现实](/news/apple-bringing-vr-external-graphics-and-game-engines-to-mac/)，但绝对不用期待任何关于[苹果AR/VR头戴式设备](/news/apple-is-working-on-an-ar-augmented-reality-vr-virtual-reality-headset-powered-by-a-wireless-wigig-hub/)，苹果公司显然在暗地里进行研发 - 但如果是的话，这些都需要直到2020年才能知晓。
+**其他我们不用指望在6月4日出现的产品:** 对于其他的苹果硬件，恐怕它们都需要一个长期的过程。不要期望会看到新的苹果手表，苹果电视盒，[第二代的AirPods](https://www.cnet.com/news/apple-airpods-2-wireless-charging-things-we-expect/)或者[小型HomePod音响](https://www.cnet.com/news/homepod-slow-sales-homepod-mini-homepod-price-cut/)。也许苹果会花一些时间去安利[AR Kit](https://www.cnet.com/pictures/best-arkit-apps/) - 它是一个软件工具集，将增强现实带进iOS - 同时[Mac里的虚拟现实](https://www.cnet.com/news/apple-bringing-vr-external-graphics-and-game-engines-to-mac/)，但绝对不用期待任何关于[苹果AR/VR头戴式设备](https://www.cnet.com/news/apple-is-working-on-an-ar-augmented-reality-vr-virtual-reality-headset-powered-by-a-wireless-wigig-hub/)，苹果公司显然在暗地里进行研发 - 即使真的要期待一下，这些都需要直到2020年才能知晓。
 
-你将看到的将是针对以上几乎所有硬件的大量新的软件以及操作系统。以下是可以期待的内容。
+你将看到的，将是针对上文提到的所有硬件而更新的大量软件以及操作系统。以下是可以期待的内容。
 
 ## iOS 12：质量高于数量
 
-在一系列[持续的]((/news/how-to-fix-the-ios-11-1-autocorrect-bug/))[缺陷](https://www.cnet.com/news/apple-updates-operating-systems-to-fix-app-crashing-bug/)[和](https://www.cnet.com/how-to/why-you-should-avoid-your-iphones-calculator/)[小故障](https://www.cnet.com/news/apple-slows-down-older-iphone-battery-issues/)后，这些问题都导致iOS11口碑不佳 - 包括[关于故意降低iPhones性能的有争议功能](/news/apple-slows-down-older-iphone-battery-issues/) - 苹果[称将会聚焦在质量而不是创新](https://www.bloomberg.com/news/articles/2018-01-30/apple-is-said-to-push-back-some-key-iphone-software-features)在它即将到来的移动操作系统中，也就是所谓的iOS 12。
+在经历了一系列[持续的]((/news/how-to-fix-the-ios-11-1-autocorrect-bug/))[缺陷](https://www.cnet.com/news/apple-updates-operating-systems-to-fix-app-crashing-bug/)[和](https://www.cnet.com/how-to/why-you-should-avoid-your-iphones-calculator/)[小故障](https://www.cnet.com/news/apple-slows-down-older-iphone-battery-issues/)后，这些问题都导致iOS11口碑不佳 - 包括[关于故意降低iPhones性能的有争议功能](https://www.cnet.com/news/apple-slows-down-older-iphone-battery-issues/) - 苹果[称将会把质量放在比创新更重要的位置](https://www.bloomberg.com/news/articles/2018-01-30/apple-is-said-to-push-back-some-key-iphone-software-features)在它即将到来的移动操作系统中，也就是所谓的iOS 12。
 
 这也许将推迟一些计划中的升级，包括重新设计的主屏，摄像头的增强以及针对AR游戏的多媒体播放器的支持，该消息来自[彭博社](https://www.bloomberg.com/news/articles/2018-01-30/apple-is-said-to-push-back-some-key-iphone-software-features)，它也是目前为止所有这些预测的主要来源。
 
@@ -61,11 +61,11 @@ AirPower早在2017年的9月份就发布了，但到现在还没有发售。
 
 iPhone 2018：最需要的功能
 
-这不代表着iOS 12不会发布一些新的功能。日本博客[Mac Otakara](http://www.macotakara.jp/blog/rumor/entry-34952.html)报道说一些更新将着重于改进Face ID，包括能够于水平景观模式解锁设备的能力。同时，彭博社也报道过苹果计划扩展它的[动态表情库](/news/getting-started-with-the-iphone-x-animoji-apple/)。同时，当然，如果动态表情（和苹果的[景深](/news/apple-face-id-truedepth-how-it-works/)摄像头技术）正在引入未来版本的iPad中，这些支持也将需要加入到iOS软件的平板系统中。
+这不代表着iOS 12不会发布一些新的功能。日本博客[Mac Otakara](http://www.macotakara.jp/blog/rumor/entry-34952.html)报道说一些更新将着重于改进Face ID，包括能够于横屏模式解锁设备的能力。同时，彭博社也报道过苹果计划扩展它的[动态表情库](https://www.cnet.com/news/getting-started-with-the-iphone-x-animoji-apple/)。同时，当然，如果动态表情（和苹果的[景深](https://www.cnet.com/news/apple-face-id-truedepth-how-it-works/)摄像头技术）正在引入未来版本的iPad中，这些支持也将需要加入到iOS软件的平板系统中。
 
-## MacOS: 双倍下注于安全
+## MacOS: 加倍关注安全
 
-不仅仅是iOS有许多软件问题。在2017年11月，[研究人员已经发现了一个巨大的安全漏洞](/news/apple-flaw-allows-macos-high-sierra-logins-without-passwords/)，它位于苹果的Mac操作系统，允许用户能够在任何Mac笔记本或者台式机上虚拟登陆，并且不需要密码。([如果你近期没有更新MacOS，这里是如何防止此类访问的方法](https://support.apple.com/en-us/HT204012)) 诸如此类，我们期待苹果能够投入更多的时间和精力在今年的WWDC中。
+存在安全问题的不仅仅是iOS系统。在2017年11月，[研究人员已经发现了一个巨大的安全漏洞](https://www.cnet.com/news/apple-flaw-allows-macos-high-sierra-logins-without-passwords/)，它位于苹果的Mac操作系统，允许用户能够在任何Mac笔记本或者台式机上虚拟登陆，并且不需要密码。([如果你近期没有更新MacOS，这里是如何防止此类访问的方法](https://support.apple.com/en-us/HT204012)) 诸如此类，我们期待苹果能够投入更多的时间和精力付诸行动改善安全问题，而不仅仅只在今年的WWDC中简单一提。
 
 ![apple-watch-faces.jpg](https://cnet4.cbsistatic.com/img/JsfogWRVDuQhU5AF9zZFW3caio0=/970x0/2014/11/27/2a3d4179-935d-459a-9c19-25d6a3eee158/apple-watch-faces.jpg)
 
@@ -75,31 +75,31 @@ iPhone 2018：最需要的功能
 
 ## WatchOS：扩展健康和健身功能
 
-现在只有很少的一些信息关于苹果如何对待它的可穿戴操作系统，但[近期预测的苹果全新的圆形表盘设计专利](/news/round-apple-watch-patent-granted/)预示了一种新的可能性。同时也有可能出现[一个更大规模的表盘商店](https://9to5mac.com/2018/04/14/watchos-4-3-1-suggests-future-support-for-third-party-watch-faces/)，或者更多的表盘定制化。否则，我们将看到一些关于继续扩展苹果手表的健康和健身功能的发布(通过HealthKit软件集)。
+现在只有很少的一些信息关于苹果如何对待它的可穿戴操作系统，但[近期预测的苹果全新的圆形表盘设计专利](https://www.cnet.com/news/round-apple-watch-patent-granted/)预示了一种新的可能性。同时也有可能出现[一个更大规模的表盘商店](https://9to5mac.com/2018/04/14/watchos-4-3-1-suggests-future-support-for-third-party-watch-faces/)，或者更多的表盘定制化。否则，我们将看到一些关于继续扩展苹果手表的健康和健身功能的发布(通过HealthKit软件集)。
 
 ## TV OS、Audio OS和Siri：让苹果电视和HomePod更加智能
 
-我们已经知道[tvOS 11.4的beta版本](/news/airplay-2-multiroom-audio-apple-tv-homepod-ios-11-4-hands-on/)将会更加紧密地结合苹果电视，集成到Home应用中，同时提供和首次于2017年WWDC揭露的AirPlay 2多房间音响功能的兼容性支持。这也许意味着更多和HomeKit的集成，苹果的[智能家居](https://www.cnet.com/smart-home/)平台，将在今年的WWDC中准备就绪。也许我们也将听到更多关于游戏和电视应用的消息。
+我们已经知道[tvOS 11.4的beta版本](/news/airplay-2-multiroom-audio-apple-tv-homepod-ios-11-4-hands-on/)将会更加紧密地结合苹果电视，集成到Home应用中，同时提供和首次于2017年WWDC发布的AirPlay 2多房间音响功能的兼容性支持。这也许意味着更多和HomeKit的集成，苹果的[智能家居](https://www.cnet.com/smart-home/)平台，将在今年的WWDC中准备就绪。也许我们也将听到更多关于游戏和电视应用的消息。
 
 ![homepod-product-photos-12](https://cnet4.cbsistatic.com/img/KaRXiRMCYAkcqVm3q0radFmPjHg=/970x0/2018/02/04/d5f53fb7-49e8-4f7d-84e0-574c3992572c/homepod-product-photos-12.jpg)
 
 Tyler Lizenby/CNET
 
-iOS 11.4也将最终部署已经承诺过的多房间语音和立体声配对功能到HomePod中。但当一个产品的硬件是顶尖的，它的软件却严重缺乏。我们希望苹果能够借HomePod发布一周年的时机，宣布针对语音操作系统的特定改进。因此，音响能够减少对于iPhone的依赖，对[亚马逊的Echo](/news/amazon-echo-alexa-devices-everything-you-need-to-know/)和[谷歌的家庭音响系统](/news/everything-you-need-to-know-about-google-home/)构成明显的挑战。
+iOS 11.4也将最终带来已经承诺过的多房间语音和立体声配对功能到HomePod中。但当一个产品的硬件是顶尖的，它的软件却严重缺乏。我们希望苹果能够借HomePod发布一周年的时机，宣布针对语音操作系统的具体改进。从而使音响能够减少对于iPhone的依赖，对[亚马逊的Echo](https://www.cnet.com/news/amazon-echo-alexa-devices-everything-you-need-to-know/)和[谷歌的家庭音响系统](https://www.cnet.com/news/everything-you-need-to-know-about-google-home/)构成明显的挑战。
 
-同时我们也关注：所有人都同意Siri需要一次严谨的重构，如果苹果依然希望和Alexa以及Google Assistant进行竞争的话。
+在如今情况下：如果苹果还希望有机会和Alexa以及Google Assistant继续竞争的话，毫无疑问，Siri需要一次彻彻底底的重构。
 
 ## 关于'Marzipan'？
 
-苹果开发者在最近几个月中最大的困扰之一就是关于“Marzipan”。这应该是初始版本的开发代号，首次由[彭博社](https://www.bloomberg.com/news/articles/2017-12-20/apple-is-said-to-have-plan-to-combine-iphone-ipad-and-mac-apps)在1月份报道，旨在为用户带来一种“使用一组能够在iPhones、iPads和Macs都运行良好的应用程序”的方式。
+苹果开发者在最近几个月中最大的困扰之一就是关于“Marzipan”。这应该是初始版本的开发代号，首次由[彭博社](https://www.bloomberg.com/news/articles/2017-12-20/apple-is-said-to-have-plan-to-combine-iphone-ipad-and-mac-apps)在1月份报道，旨在为用户带来一种“使用一组能够在iPhone、iPad和Mac都运行良好的应用程序”的方式。
 
-当许多人都在假设这意味着最终[iOS应用可能运行在Macs](/news/apple-may-offer-combined-ios-and-mac-apps-next-year/)中 - 如果不是一个统一的iOS/MacOS操作系统 - 真相也许就不会那么戏剧性。根据[苹果权威专家John Gruber](https://daringfireball.net/2018/04/scuttlebutt_regarding_ui_project)，他对于Marzipan的名字一无所知。但他称苹果目前显然正在研究一种共享工具集，它能够将iOS和Mac的应用在一个通用的环境中同时开发，至少类似于以上消息。相反地，目前的情况是开发者必须要为每一个平台设计，开发和部署不同的版本，这导致了很多重复的工作。
+虽然人们都说，即使未来iOS和MacOS没有整合成一个操作系统，那最终[iOS系统的应用也可以在MacOS上运行](https://www.cnet.com/news/apple-may-offer-combined-ios-and-mac-apps-next-year/)。然而真相可能没有那么激动人心。根据[苹果权威专家John Gruber](https://daringfireball.net/2018/04/scuttlebutt_regarding_ui_project)，他对于Marzipan的名字一无所知。但他称苹果目前显然正在研究一种共享工具集，它能够将iOS和Mac的应用在一个通用的环境中同时开发，至少在一定程度上。相较而言，目前的情况是开发者必须要为每一个平台设计、开发和部署不同的版本，这导致了很多重复的工作。
 
 Gruber的说法揭露了一种更少野心，但同时更加现实的为iOS和MacOS服务的协作方式 - 虽然是一种听起来对开发者更实际的方式，但也在技术上更具可能性。但是，他还指出“这将是2019年的事情” - 意味着你应当不会在今年的WWDC中听到任何公开的披露。
 
 ## 让我们6月4日拭目以待
 
-CNET将全程报道WWDC，包括预览，圣何塞的发布会现场直播以及许多后续的更近报道。保持关注
+CNET将全程报道WWDC，包括预览，圣何塞的发布会现场直播以及许多后续的更近报道。保持关注。
 
 [iPhone 2018](/news/iphone-2018-iphone-x-plus-launch-date-specs-price-release-date-rumors/)：所有关于规格、功能和发布时间的预测
 

--- a/TODO1/wwdc-2018-rumors-ios-12-new-macbook-air-ipad-pro-homepod.md
+++ b/TODO1/wwdc-2018-rumors-ios-12-new-macbook-air-ipad-pro-homepod.md
@@ -5,23 +5,23 @@
 > * 译者：[Dandy Xu](https://github.com/dandyxu)
 > * 校对者：[shisaq](https://github.com/shisaq)
 
-# WWDC 2018：关于iOS 12、iPad Pro、新MacBook及更多产品的所有预测
+# WWDC 2018：关于 iOS 12、iPad Pro、新 MacBook 及更多产品的所有预测
 
-## 当蒂姆库克(Tim Cook)在6月4日走进圣何塞(San Jose)的发布会现场时将会发生什么事情？(译者注：圣何塞(San Jose)是美国加州的第三大城市)
+## 当蒂姆库克 (Tim Cook) 在 6 月 4 日走进圣何塞 (San Jose) 的发布会现场时将会发生什么事情？(译者注：圣何塞 (San Jose) 是美国加州的第三大城市)
 
-我们距离[苹果公司](https://www.cnet.com/apple/)的下一个正式发布会只有2周的时间了，我们通常可以在发布会上一窥该公司的未来。
+我们距离 [苹果公司](https://www.cnet.com/apple/) 的下一个正式发布会只有2周的时间了，我们通常可以在发布会上一窥该公司的未来。
 
-苹果公司一年一度的[世界开发者大会](https://www.cnet.com/wwdc)提供了关于下一代操作系统和软件应用的线索和方向，它们为该公司的[iPhone](https://www.cnet.com/products/apple-iphone-x/review/)、[iPad](https://www.cnet.com/products/apple-ipad-2018-9-7-inch/review/)、Macs、手表、[HomePod](https://www.cnet.com/products/apple-homepod/review/)音响和[苹果电视](https://www.cnet.com/products/apple-tv-4k/review/)提供动力。今年的发布会于6月4日至8日，在美国加州圣何塞市的McEnery Convention Center举行，同时也给第三方开发者们提供了一个和苹果管理层、工程师以及产品设计人员沟通交流的机会。
+苹果公司一年一度的 [世界开发者大会](https://www.cnet.com/wwdc) 提供了关于下一代操作系统和软件应用的线索和方向，它们为该公司的 [iPhone](https://www.cnet.com/products/apple-iphone-x/review/)、[iPad](https://www.cnet.com/products/apple-ipad-2018-9-7-inch/review/)、Macs、手表、[HomePod](https://www.cnet.com/products/apple-homepod/review/) 音响和 [苹果电视](https://www.cnet.com/products/apple-tv-4k/review/) 提供动力。今年的发布会于 6 月 4 日至 8 日，在美国加州圣何塞市的 McEnery Convention Center 举行，同时也给第三方开发者们提供了一个和苹果管理层、工程师以及产品设计人员沟通交流的机会。
 
-[WWDC](https://www.cnet.com/wwdc/)中极有可能揭露将在今年内实现的针对操作系统、应用、服务以及软件框架的更新升级。但是，苹果有时也会用来发布一些新的硬件。在我们进行更深层次的软件预计分析之前，我们先来探讨一下可能会发布哪些新的硬件。
+[WWDC](https://www.cnet.com/wwdc/) 中极有可能揭露将在今年内实现的针对操作系统、应用、服务以及软件框架的更新升级。但是，苹果有时也会用来发布一些新的硬件。在我们进行更深层次的软件预计分析之前，我们先来探讨一下可能会发布哪些新的硬件。
 
-## 可能会发布新的iPad Pro、MacBook及更多的硬件
+## 可能会发布新的 iPad Pro、MacBook 及更多的硬件
 
-当苹果公司CEO蒂姆库克(Tim Cook)在6月4日站在发布会舞台上时，不要期望能够看到新的高端iPhones或者新版本的Mac Pro。[iPhone X](https://www.cnet.com/products/apple-iphone-x/review/)、[iPhone 8](https://www.cnet.com/products/apple-iphone-8-review/)和[iPhone 8 Plus](https://www.cnet.com/products/apple-iphone-8-plus/review/)已经如期在去年9月份发布了，同时苹果也已经确认了[新的Mac Pro将于2019年发布](https://www.cnet.com/news/the-new-mac-pro-is-coming-in-2019/)。同样的，[HomePod](https://www.cnet.com/products/apple-homepod/review/)音响和[入门级别的iPad](https://www.cnet.com/products/apple-ipad-2018-9-7-inch/review/)也分别于2月和3月刚刚全新发布。
+当苹果公司 CEO 蒂姆库克 (Tim Cook) 在 6 月 4 日站在发布会舞台上时，不要期望能够看到新的高端 iPhone 或者新版本的 Mac Pro。[iPhone X](https://www.cnet.com/products/apple-iphone-x/review/)、[iPhone 8](https://www.cnet.com/products/apple-iphone-8-review/) 和[iPhone 8 Plus](https://www.cnet.com/products/apple-iphone-8-plus/review/) 已经如期在去年 9 月份发布了，同时苹果也已经确认了 [新的Mac Pro将于2019年发布](https://www.cnet.com/news/the-new-mac-pro-is-coming-in-2019/)。同样的，[HomePod](https://www.cnet.com/products/apple-homepod/review/) 音响和 [入门级别的iPad](https://www.cnet.com/products/apple-ipad-2018-9-7-inch/review/) 也分别于2月和3月刚刚全新发布。
 
-但这里有4个产品类别，极有可能在6月份进行发布：
+但这里有 4 个产品类别，极有可能在 6 月份进行发布：
 
-**MacBooks and iMacs:** 在去年的WWDC中，苹果几乎将整条笔记本和台式机的产品线进行了更新。现在，一年过去了，将全部产品升级到最新的[第8代Intel处理器](https://www.cnet.com/news/kaby-lake-coffee-lake-and-beyond-what-we-know-about-the-next-intel-chips/)，尽管有些枯燥，但确实是最简单的升级做法。但是否需要更大规模的设计改革 - 例如重新思考[蝴蝶键盘的问题](https://www.cnet.com/news/apple-macbook-keyboard-issue-prompts-lawsuit/)和在[MacBook Pro笔记本](https://www.cnet.com/products/apple-macbook-pro-with-touch-bar-15-inch-2017/review/)上[仍然存在争议的Touch Bar功能](https://www.cnet.com/news/apple-macbook-pro-touch-problems-commentary/)，仍然有待观察。同样的问题也适用于MacBook Air，一直有预测说该系列将会迎来新的型号。
+**MacBooks and iMacs:** 在去年的WWDC中，苹果几乎将整条笔记本和台式机的产品线进行了更新。现在，一年过去了，将全部产品升级到最新的 [第8代Intel处理器](https://www.cnet.com/news/kaby-lake-coffee-lake-and-beyond-what-we-know-about-the-next-intel-chips/)，尽管有些枯燥，但确实是最简单的升级做法。但是否需要更大规模的设计改革 - 例如重新思考 [蝴蝶键盘的问题](https://www.cnet.com/news/apple-macbook-keyboard-issue-prompts-lawsuit/) 和在 [MacBook Pro笔记本](https://www.cnet.com/products/apple-macbook-pro-with-touch-bar-15-inch-2017/review/) 上 [仍然存在争议的Touch Bar功能](https://www.cnet.com/news/apple-macbook-pro-touch-problems-commentary/)，仍然有待观察。同样的问题也适用于 MacBook Air，一直有预测说该系列将会迎来新的型号。
 
 阅读：[2018 MacBook Air：所有关于规格、价格以及发布时间的预测](https://www.cnet.com/news/2018-macbook-air-all-the-rumors-on-specs-price-release-date/)
 
@@ -29,77 +29,77 @@
 
 Sarah Tew/CNET
 
-**iPad Pros:** 苹果刚刚在3月给[iPad Pro](https://www.cnet.com/products/apple-ipad-pro-10-5-inch-2017/review/)产品线引入了一个重要的功能，就是让新的[入门级iPad](https://www.cnet.com/products/apple-ipad-2018-9-7-inch/review/)兼容手写笔。人们认为这种举措将使价格更高的iPad Pro可以向iPhone X的风格迈进：去掉home键，同时添加Face ID。
+**iPad Pros:** 苹果刚刚在 3 月给 [iPad Pro](https://www.cnet.com/products/apple-ipad-pro-10-5-inch-2017/review/) 产品线引入了一个重要的功能，就是让新的 [入门级iPad](https://www.cnet.com/products/apple-ipad-2018-9-7-inch/review/) 兼容手写笔。人们认为这种举措将使价格更高的 iPad Pro 可以向 iPhone X 的风格迈进：去掉 home 键，同时添加 Face ID。
 
 阅读：[iPad Pro 2018：所有关于规格、价格以及发布时间的预测](https://www.cnet.com/news/ipad-pro-2018-all-the-rumors-on-specs-price-release-date/)
 
-**iPhone SE 2:** 如我们之前说过的，iPhone的大升级通常都在9月份。但一直有预测说[iPhone SE](https://www.cnet.com/products/apple-iphone-se-review/) - 即首次在2016年3月亮相的入门级iPhone，或多或少是该升级了。是否采用全屏幕的iPhone X设计(看起来不太可能)或者只是基于现有模块的规格升级(更有可能)，这些都是未知的。
+**iPhone SE 2:** 如我们之前说过的，iPhone 的大升级通常都在 9 月份。但一直有预测说 [iPhone SE](https://www.cnet.com/products/apple-iphone-se-review/) - 即首次在 2016 年 3 月亮相的入门级 iPhone，或多或少是该升级了。是否采用全屏幕的 iPhone X 设计(看起来不太可能)或者只是基于现有模块的规格升级(更有可能)，这些都是未知的。
 
 阅读：[iPhone SE 2：预测的规格、价格、发布时间](https://www.cnet.com/news/iphone-se-2-launch-date-specs-price-release-date-rumors-notch/)
 
-**Apple AirPower:** 苹果公司的全球市场高级副总裁Phil Schiller在2017年9月介绍这个和iPhone X搭配使用的，多设备的充电设备时，他说这将在"明年"推出。所以，直到2019年的1月1日，你都不能说它推出“晚”了，有一种假设是苹果公司希望在这个产品发布一周年之前，将它放上货架出售。WWDC将会是一个绝佳的机会去宣布它的价格和发售日期 - 也许我们还能看到和AirPower兼容的AirPods收纳盒。
+**Apple AirPower:** 苹果公司的全球市场高级副总裁 Phil Schiller 在 2017 年 9 月介绍这个和 iPhone X 搭配使用的，多设备的充电设备时，他说这将在“明年”推出。所以，直到 2019 年的 1 月 1 日，你都不能说它推出“晚”了，有一种假设是苹果公司希望在这个产品发布一周年之前，将它放上货架出售。WWDC 将会是一个绝佳的机会去宣布它的价格和发售日期 - 也许我们还能看到和 AirPower 兼容的 AirPods 收纳盒。
 
 阅读：[AirPower: 我们所知道的苹果无线充电板](https://www.cnet.com/news/apple-airpower-wireless-charger-everything-we-know/)
 
 ![airpower-charging](https://cnet3.cbsistatic.com/img/ncNN2P2MqPIxuYdY7jRaGHHUkzM=/970x0/2017/09/12/02937a84-4f0a-4611-8af2-4a5764b95055/screen-shot-2017-09-12-at-2-44-50-pm.png)
 
-AirPower早在2017年的9月份就发布了，但到现在还没有发售。
+AirPower 早在 2017 年的 9 月份就发布了，但到现在还没有发售。
 
 截图来自Alexandra Able/CNET
 
-**其他我们不用指望在6月4日出现的产品:** 对于其他的苹果硬件，恐怕它们都需要一个长期的过程。不要期望会看到新的苹果手表，苹果电视盒，[第二代的AirPods](https://www.cnet.com/news/apple-airpods-2-wireless-charging-things-we-expect/)或者[小型HomePod音响](https://www.cnet.com/news/homepod-slow-sales-homepod-mini-homepod-price-cut/)。也许苹果会花一些时间去安利[AR Kit](https://www.cnet.com/pictures/best-arkit-apps/) - 它是一个软件工具集，将增强现实带进iOS - 同时[Mac里的虚拟现实](https://www.cnet.com/news/apple-bringing-vr-external-graphics-and-game-engines-to-mac/)，但绝对不用期待任何关于[苹果AR/VR头戴式设备](https://www.cnet.com/news/apple-is-working-on-an-ar-augmented-reality-vr-virtual-reality-headset-powered-by-a-wireless-wigig-hub/)，苹果公司显然在暗地里进行研发 - 即使真的要期待一下，这些都需要直到2020年才能知晓。
+**其他我们不用指望在6月4日出现的产品:** 对于其他的苹果硬件，恐怕它们都需要一个长期的过程。不要期望会看到新的苹果手表，苹果电视盒，[第二代的AirPods](https://www.cnet.com/news/apple-airpods-2-wireless-charging-things-we-expect/) 或者 [小型HomePod音响](https://www.cnet.com/news/homepod-slow-sales-homepod-mini-homepod-price-cut/)。也许苹果会花一些时间去安利 [AR Kit](https://www.cnet.com/pictures/best-arkit-apps/) - 它是一个软件工具集，将增强现实带进iOS - 同时 [Mac里的虚拟现实](https://www.cnet.com/news/apple-bringing-vr-external-graphics-and-game-engines-to-mac/)，但绝对不用期待任何关于 [苹果AR/VR头戴式设备](https://www.cnet.com/news/apple-is-working-on-an-ar-augmented-reality-vr-virtual-reality-headset-powered-by-a-wireless-wigig-hub/)，苹果公司显然在暗地里进行研发 - 即使真的要期待一下，这些都需要直到 2020 年才能知晓。
 
 你将看到的，将是针对上文提到的所有硬件而更新的大量软件以及操作系统。以下是可以期待的内容。
 
 ## iOS 12：质量高于数量
 
-在经历了一系列[持续的](https://www.cnet.com/news/how-to-fix-the-ios-11-1-autocorrect-bug/)[缺陷](https://www.cnet.com/news/apple-updates-operating-systems-to-fix-app-crashing-bug/)[和](https://www.cnet.com/how-to/why-you-should-avoid-your-iphones-calculator/)[小故障](https://www.cnet.com/news/apple-slows-down-older-iphone-battery-issues/)后，这些问题都导致iOS11口碑不佳 - 包括[关于故意降低iPhones性能的有争议功能](https://www.cnet.com/news/apple-slows-down-older-iphone-battery-issues/) - 苹果[称将会把质量放在比创新更重要的位置](https://www.bloomberg.com/news/articles/2018-01-30/apple-is-said-to-push-back-some-key-iphone-software-features)在它即将到来的移动操作系统中，也就是所谓的iOS 12。
+在经历了一系列 [持续的](https://www.cnet.com/news/how-to-fix-the-ios-11-1-autocorrect-bug/) [缺陷](https://www.cnet.com/news/apple-updates-operating-systems-to-fix-app-crashing-bug/) [和](https://www.cnet.com/how-to/why-you-should-avoid-your-iphones-calculator/) [小故障](https://www.cnet.com/news/apple-slows-down-older-iphone-battery-issues/) 后，这些问题都导致iOS11口碑不佳 - 包括 [关于故意降低 iPhones 性能的有争议功能](https://www.cnet.com/news/apple-slows-down-older-iphone-battery-issues/) - 苹果 [称将会把质量放在比创新更重要的位置](https://www.bloomberg.com/news/articles/2018-01-30/apple-is-said-to-push-back-some-key-iphone-software-features) 在它即将到来的移动操作系统中，也就是所谓的 iOS 12。
 
-这也许将推迟一些计划中的升级，包括重新设计的主屏，摄像头的增强以及针对AR游戏的多媒体播放器的支持，该消息来自[彭博社](https://www.bloomberg.com/news/articles/2018-01-30/apple-is-said-to-push-back-some-key-iphone-software-features)，它也是目前为止所有这些预测的主要来源。
+这也许将推迟一些计划中的升级，包括重新设计的主屏，摄像头的增强以及针对AR游戏的多媒体播放器的支持，该消息来自 [彭博社](https://www.bloomberg.com/news/articles/2018-01-30/apple-is-said-to-push-back-some-key-iphone-software-features)，它也是目前为止所有这些预测的主要来源。
 
 [![iphone-8-rendering-armend.png](https://cnet2.cbsistatic.com/img/H0LiIaasuxLf5kdAoMYgFrmTEZA=/724x407/2018/02/28/909a855f-937f-4d63-920b-83e3fa456607/iphone-x2.jpg)](https://www.cnet.com/pictures/iphone-2018-most-wanted-features/)
 
 iPhone 2018：最需要的功能
 
-这不代表着iOS 12不会发布一些新的功能。日本博客[Mac Otakara](http://www.macotakara.jp/blog/rumor/entry-34952.html)报道说一些更新将着重于改进Face ID，包括能够于横屏模式解锁设备的能力。同时，彭博社也报道过苹果计划扩展它的[动态表情库](https://www.cnet.com/news/getting-started-with-the-iphone-x-animoji-apple/)。同时，当然，如果动态表情（和苹果的[景深](https://www.cnet.com/news/apple-face-id-truedepth-how-it-works/)摄像头技术）正在引入未来版本的iPad中，这些支持也将需要加入到iOS软件的平板系统中。
+这不代表着 iOS 12 不会发布一些新的功能。日本博客 [Mac Otakara](http://www.macotakara.jp/blog/rumor/entry-34952.html) 报道说一些更新将着重于改进 Face ID，包括能够于横屏模式解锁设备的能力。同时，彭博社也报道过苹果计划扩展它的 [动态表情库](https://www.cnet.com/news/getting-started-with-the-iphone-x-animoji-apple/)。同时，当然，如果动态表情（和苹果的 [景深](https://www.cnet.com/news/apple-face-id-truedepth-how-it-works/) 摄像头技术）正在引入未来版本的 iPad 中，这些支持也将需要加入到 iOS 软件的平板系统中。
 
 ## MacOS: 加倍关注安全
 
-存在安全问题的不仅仅是iOS系统。在2017年11月，[研究人员已经发现了一个巨大的安全漏洞](https://www.cnet.com/news/apple-flaw-allows-macos-high-sierra-logins-without-passwords/)，它位于苹果的Mac操作系统，允许用户能够在任何Mac笔记本或者台式机上虚拟登陆，并且不需要密码。([如果你近期没有更新MacOS，这里是如何防止此类访问的方法](https://support.apple.com/en-us/HT204012)) 诸如此类，我们期待苹果能够投入更多的时间和精力付诸行动改善安全问题，而不仅仅只在今年的WWDC中简单一提。
+存在安全问题的不仅仅是 iOS 系统。在 2017 年 11 月，[研究人员已经发现了一个巨大的安全漏洞](https://www.cnet.com/news/apple-flaw-allows-macos-high-sierra-logins-without-passwords/)，它位于苹果的 Mac 操作系统，允许用户能够在任何 Mac 笔记本或者台式机上虚拟登陆，并且不需要密码。([如果你近期没有更新MacOS，这里是如何防止此类访问的方法](https://support.apple.com/en-us/HT204012)) 诸如此类，我们期待苹果能够投入更多的时间和精力付诸行动改善安全问题，而不仅仅只在今年的WWDC中简单一提。
 
 ![apple-watch-faces.jpg](https://cnet4.cbsistatic.com/img/JsfogWRVDuQhU5AF9zZFW3caio0=/970x0/2014/11/27/2a3d4179-935d-459a-9c19-25d6a3eee158/apple-watch-faces.jpg)
 
 现在到了给苹果手表添加更多表盘的时间？
 
-截图来自César Salza/CNET
+截图来自 César Salza/CNET
 
 ## WatchOS：扩展健康和健身功能
 
-现在只有很少的一些信息关于苹果如何对待它的可穿戴操作系统，但[近期预测的苹果全新的圆形表盘设计专利](https://www.cnet.com/news/round-apple-watch-patent-granted/)预示了一种新的可能性。同时也有可能出现[一个更大规模的表盘商店](https://9to5mac.com/2018/04/14/watchos-4-3-1-suggests-future-support-for-third-party-watch-faces/)，或者更多的表盘定制化。否则，我们将看到一些关于继续扩展苹果手表的健康和健身功能的发布(通过HealthKit软件集)。
+现在只有很少的一些信息关于苹果如何对待它的可穿戴操作系统，但 [近期预测的苹果全新的圆形表盘设计专利](https://www.cnet.com/news/round-apple-watch-patent-granted/) 预示了一种新的可能性。同时也有可能出现 [一个更大规模的表盘商店](https://9to5mac.com/2018/04/14/watchos-4-3-1-suggests-future-support-for-third-party-watch-faces/)，或者更多的表盘定制化。否则，我们将看到一些关于继续扩展苹果手表的健康和健身功能的发布(通过 HealthKit 软件集)。
 
-## TV OS、Audio OS和Siri：让苹果电视和HomePod更加智能
+## TV OS、Audio OS 和 Siri：让苹果电视和 HomePod 更加智能
 
-我们已经知道[tvOS 11.4的beta版本](https://www.cnet.com/news/airplay-2-multiroom-audio-apple-tv-homepod-ios-11-4-hands-on/)将会更加紧密地结合苹果电视，集成到Home应用中，同时提供和首次于2017年WWDC发布的AirPlay 2多房间音响功能的兼容性支持。这也许意味着更多和HomeKit的集成，苹果的[智能家居](https://www.cnet.com/smart-home/)平台，将在今年的WWDC中准备就绪。也许我们也将听到更多关于游戏和电视应用的消息。
+我们已经知道 [tvOS 11.4 的 beta 版本](https://www.cnet.com/news/airplay-2-multiroom-audio-apple-tv-homepod-ios-11-4-hands-on/) 将会更加紧密地结合苹果电视，集成到 Home 应用中，同时提供和首次于 2017 年 WWDC 发布的 AirPlay 2 多房间音响功能的兼容性支持。这也许意味着更多和 HomeKit 的集成，苹果的 [智能家居](https://www.cnet.com/smart-home/) 平台，将在今年的 WWDC 中准备就绪。也许我们也将听到更多关于游戏和电视应用的消息。
 
 ![homepod-product-photos-12](https://cnet4.cbsistatic.com/img/KaRXiRMCYAkcqVm3q0radFmPjHg=/970x0/2018/02/04/d5f53fb7-49e8-4f7d-84e0-574c3992572c/homepod-product-photos-12.jpg)
 
 Tyler Lizenby/CNET
 
-iOS 11.4也将最终带来已经承诺过的多房间语音和立体声配对功能到HomePod中。但当一个产品的硬件是顶尖的，它的软件却严重缺乏。我们希望苹果能够借HomePod发布一周年的时机，宣布针对语音操作系统的具体改进。从而使音响能够减少对于iPhone的依赖，对[亚马逊的Echo](https://www.cnet.com/news/amazon-echo-alexa-devices-everything-you-need-to-know/)和[谷歌的家庭音响系统](https://www.cnet.com/news/everything-you-need-to-know-about-google-home/)构成明显的挑战。
+iOS 11.4 也将最终带来已经承诺过的多房间语音和立体声配对功能到 HomePod 中。但当一个产品的硬件是顶尖的，它的软件却严重缺乏。我们希望苹果能够借 HomePod 发布一周年的时机，宣布针对语音操作系统的具体改进。从而使音响能够减少对于 iPhone 的依赖，对 [亚马逊的 Echo](https://www.cnet.com/news/amazon-echo-alexa-devices-everything-you-need-to-know/) 和 [谷歌的家庭音响系统](https://www.cnet.com/news/everything-you-need-to-know-about-google-home/) 构成明显的挑战。
 
-在如今情况下：如果苹果还希望有机会和Alexa以及Google Assistant继续竞争的话，毫无疑问，Siri需要一次彻彻底底的重构。
+在如今情况下：如果苹果还希望有机会和 Alexa 以及 Google Assistant 继续竞争的话，毫无疑问，Siri 需要一次彻彻底底的重构。
 
 ## 关于'Marzipan'？
 
-苹果开发者在最近几个月中最大的困扰之一就是关于“Marzipan”。这应该是初始版本的开发代号，首次由[彭博社](https://www.bloomberg.com/news/articles/2017-12-20/apple-is-said-to-have-plan-to-combine-iphone-ipad-and-mac-apps)在1月份报道，旨在为用户带来一种“使用一组能够在iPhone、iPad和Mac都运行良好的应用程序”的方式。
+苹果开发者在最近几个月中最大的困扰之一就是关于“Marzipan”。这应该是初始版本的开发代号，首次由 [彭博社](https://www.bloomberg.com/news/articles/2017-12-20/apple-is-said-to-have-plan-to-combine-iphone-ipad-and-mac-apps) 在 1 月份报道，旨在为用户带来一种“使用一组能够在 iPhone、iPad 和 Mac 都运行良好的应用程序”的方式。
 
-虽然人们都说，即使未来iOS和MacOS没有整合成一个操作系统，那最终[iOS系统的应用也可以在MacOS上运行](https://www.cnet.com/news/apple-may-offer-combined-ios-and-mac-apps-next-year/)。然而真相可能没有那么激动人心。根据[苹果权威专家John Gruber](https://daringfireball.net/2018/04/scuttlebutt_regarding_ui_project)，他对于Marzipan的名字一无所知。但他称苹果目前显然正在研究一种共享工具集，它能够将iOS和Mac的应用在一个通用的环境中同时开发，至少在一定程度上。相较而言，目前的情况是开发者必须要为每一个平台设计、开发和部署不同的版本，这导致了很多重复的工作。
+虽然人们都说，即使未来 iOS 和 MacOS 没有整合成一个操作系统，那最终 [ iOS 系统的应用也可以在 MacOS 上运行](https://www.cnet.com/news/apple-may-offer-combined-ios-and-mac-apps-next-year/)。然而真相可能没有那么激动人心。根据 [苹果权威专家 John Gruber ](https://daringfireball.net/2018/04/scuttlebutt_regarding_ui_project)，他对于 Marzipan 的名字一无所知。但他称苹果目前显然正在研究一种共享工具集，它能够将 iOS 和 Mac 的应用在一个通用的环境中同时开发，至少在一定程度上。相较而言，目前的情况是开发者必须要为每一个平台设计、开发和部署不同的版本，这导致了很多重复的工作。
 
-Gruber的说法揭露了一种更少野心，但同时更加现实的为iOS和MacOS服务的协作方式 - 虽然是一种听起来对开发者更实际的方式，但也在技术上更具可能性。但是，他还指出“这将是2019年的事情” - 意味着你应当不会在今年的WWDC中听到任何公开的披露。
+Gruber 的说法揭露了一种更少野心，但同时更加现实的为 iOS 和 MacOS 服务的协作方式 - 虽然是一种听起来对开发者更实际的方式，但也在技术上更具可能性。但是，他还指出“这将是 2019 年的事情” - 意味着你应当不会在今年的 WWDC 中听到任何公开的披露。
 
-## 让我们6月4日拭目以待
+## 让我们 6 月 4 日拭目以待
 
-CNET将全程报道WWDC，包括预览，圣何塞的发布会现场直播以及许多后续的更近报道。保持关注。
+CNET 将全程报道 WWDC，包括预览，圣何塞的发布会现场直播以及许多后续的更近报道。保持关注。
 
 [iPhone 2018](https://www.cnet.com/news/iphone-2018-iphone-x-plus-launch-date-specs-price-release-date-rumors/)：所有关于规格、功能和发布时间的预测
 

--- a/TODO1/wwdc-2018-rumors-ios-12-new-macbook-air-ipad-pro-homepod.md
+++ b/TODO1/wwdc-2018-rumors-ios-12-new-macbook-air-ipad-pro-homepod.md
@@ -5,7 +5,7 @@
 > * 译者：[Dandy Xu](https://github.com/dandyxu)
 > * 校对者：[shisaq](https://github.com/shisaq)
 
-# WWDC 2018：关于iOS 12、iPad Pro、新MacBooks及更多产品的所有预测
+# WWDC 2018：关于iOS 12、iPad Pro、新MacBook及更多产品的所有预测
 
 ## 当蒂姆库克(Tim Cook)在6月4日走进圣何塞(San Jose)的发布会现场时将会发生什么事情？(译者注：圣何塞(San Jose)是美国加州的第三大城市)
 

--- a/TODO1/wwdc-2018-rumors-ios-12-new-macbook-air-ipad-pro-homepod.md
+++ b/TODO1/wwdc-2018-rumors-ios-12-new-macbook-air-ipad-pro-homepod.md
@@ -7,7 +7,7 @@
 
 # WWDC 2018：关于 iOS 12、iPad Pro、新 MacBook 及更多产品的所有预测
 
-## 当蒂姆库克 (Tim Cook) 在 6 月 4 日走进圣何塞 (San Jose) 的发布会现场时将会发生什么事情？(译者注：圣何塞 (San Jose) 是美国加州的第三大城市)
+## 当蒂姆库克（Tim Cook）在 6 月 4 日走进圣何塞（San Jose）的发布会现场时将会发生什么事情？（译者注：圣何塞（San Jose）是美国加州的第三大城市）
 
 我们距离 [苹果公司](https://www.cnet.com/apple/) 的下一个正式发布会只有2周的时间了，我们通常可以在发布会上一窥该公司的未来。
 
@@ -37,7 +37,7 @@ Sarah Tew/CNET
 
 阅读：[iPhone SE 2：预测的规格、价格、发布时间](https://www.cnet.com/news/iphone-se-2-launch-date-specs-price-release-date-rumors-notch/)
 
-**Apple AirPower:** 苹果公司的全球市场高级副总裁 Phil Schiller 在 2017 年 9 月介绍这个和 iPhone X 搭配使用的，多设备的充电设备时，他说这将在“明年”推出。所以，直到 2019 年的 1 月 1 日，你都不能说它推出“晚”了，有一种假设是苹果公司希望在这个产品发布一周年之前，将它放上货架出售。WWDC 将会是一个绝佳的机会去宣布它的价格和发售日期 - 也许我们还能看到和 AirPower 兼容的 AirPods 收纳盒。
+**Apple AirPower：** 苹果公司的全球市场高级副总裁 Phil Schiller 在 2017 年 9 月介绍这个和 iPhone X 搭配使用的，多设备的充电设备时，他说这将在“明年”推出。所以，直到 2019 年的 1 月 1 日，你都不能说它推出“晚”了，有一种假设是苹果公司希望在这个产品发布一周年之前，将它放上货架出售。WWDC 将会是一个绝佳的机会去宣布它的价格和发售日期 - 也许我们还能看到和 AirPower 兼容的 AirPods 收纳盒。
 
 阅读：[AirPower: 我们所知道的苹果无线充电板](https://www.cnet.com/news/apple-airpower-wireless-charger-everything-we-know/)
 
@@ -47,13 +47,13 @@ AirPower 早在 2017 年的 9 月份就发布了，但到现在还没有发售�
 
 截图来自Alexandra Able/CNET
 
-**其他我们不用指望在6月4日出现的产品:** 对于其他的苹果硬件，恐怕它们都需要一个长期的过程。不要期望会看到新的苹果手表，苹果电视盒，[第二代的AirPods](https://www.cnet.com/news/apple-airpods-2-wireless-charging-things-we-expect/) 或者 [小型HomePod音响](https://www.cnet.com/news/homepod-slow-sales-homepod-mini-homepod-price-cut/)。也许苹果会花一些时间去安利 [AR Kit](https://www.cnet.com/pictures/best-arkit-apps/) - 它是一个软件工具集，将增强现实带进iOS - 同时 [Mac里的虚拟现实](https://www.cnet.com/news/apple-bringing-vr-external-graphics-and-game-engines-to-mac/)，但绝对不用期待任何关于 [苹果AR/VR头戴式设备](https://www.cnet.com/news/apple-is-working-on-an-ar-augmented-reality-vr-virtual-reality-headset-powered-by-a-wireless-wigig-hub/)，苹果公司显然在暗地里进行研发 - 即使真的要期待一下，这些都需要直到 2020 年才能知晓。
+**其他我们不用指望在6月4日出现的产品：** 对于其他的苹果硬件，恐怕它们都需要一个长期的过程。不要期望会看到新的苹果手表，苹果电视盒，[第二代的AirPods](https://www.cnet.com/news/apple-airpods-2-wireless-charging-things-we-expect/) 或者 [小型HomePod音响](https://www.cnet.com/news/homepod-slow-sales-homepod-mini-homepod-price-cut/)。也许苹果会花一些时间去安利 [AR Kit](https://www.cnet.com/pictures/best-arkit-apps/) — 它是一个软件工具集，将增强现实带进iOS — 同时 [Mac里的虚拟现实](https://www.cnet.com/news/apple-bringing-vr-external-graphics-and-game-engines-to-mac/)，但绝对不用期待任何关于 [苹果AR/VR头戴式设备](https://www.cnet.com/news/apple-is-working-on-an-ar-augmented-reality-vr-virtual-reality-headset-powered-by-a-wireless-wigig-hub/)，苹果公司显然在暗地里进行研发 - 即使真的要期待一下，这些都需要直到 2020 年才能知晓。
 
 你将看到的，将是针对上文提到的所有硬件而更新的大量软件以及操作系统。以下是可以期待的内容。
 
 ## iOS 12：质量高于数量
 
-在经历了一系列 [持续的](https://www.cnet.com/news/how-to-fix-the-ios-11-1-autocorrect-bug/) [缺陷](https://www.cnet.com/news/apple-updates-operating-systems-to-fix-app-crashing-bug/) [和](https://www.cnet.com/how-to/why-you-should-avoid-your-iphones-calculator/) [小故障](https://www.cnet.com/news/apple-slows-down-older-iphone-battery-issues/) 后，这些问题都导致iOS11口碑不佳 - 包括 [关于故意降低 iPhones 性能的有争议功能](https://www.cnet.com/news/apple-slows-down-older-iphone-battery-issues/) - 苹果 [称将会把质量放在比创新更重要的位置](https://www.bloomberg.com/news/articles/2018-01-30/apple-is-said-to-push-back-some-key-iphone-software-features) 在它即将到来的移动操作系统中，也就是所谓的 iOS 12。
+在经历了一系列 [持续的](https://www.cnet.com/news/how-to-fix-the-ios-11-1-autocorrect-bug/) [缺陷](https://www.cnet.com/news/apple-updates-operating-systems-to-fix-app-crashing-bug/) [和](https://www.cnet.com/how-to/why-you-should-avoid-your-iphones-calculator/) [小故障](https://www.cnet.com/news/apple-slows-down-older-iphone-battery-issues/) 后，这些问题都导致iOS11口碑不佳 — 包括 [关于故意降低 iPhones 性能的有争议功能](https://www.cnet.com/news/apple-slows-down-older-iphone-battery-issues/) — 苹果 [称将会把质量放在比创新更重要的位置](https://www.bloomberg.com/news/articles/2018-01-30/apple-is-said-to-push-back-some-key-iphone-software-features) 在它即将到来的移动操作系统中，也就是所谓的 iOS 12。
 
 这也许将推迟一些计划中的升级，包括重新设计的主屏，摄像头的增强以及针对AR游戏的多媒体播放器的支持，该消息来自 [彭博社](https://www.bloomberg.com/news/articles/2018-01-30/apple-is-said-to-push-back-some-key-iphone-software-features)，它也是目前为止所有这些预测的主要来源。
 
@@ -75,7 +75,7 @@ iPhone 2018：最需要的功能
 
 ## WatchOS：扩展健康和健身功能
 
-现在只有很少的一些信息关于苹果如何对待它的可穿戴操作系统，但 [近期预测的苹果全新的圆形表盘设计专利](https://www.cnet.com/news/round-apple-watch-patent-granted/) 预示了一种新的可能性。同时也有可能出现 [一个更大规模的表盘商店](https://9to5mac.com/2018/04/14/watchos-4-3-1-suggests-future-support-for-third-party-watch-faces/)，或者更多的表盘定制化。否则，我们将看到一些关于继续扩展苹果手表的健康和健身功能的发布(通过 HealthKit 软件集)。
+现在只有很少的一些信息关于苹果如何对待它的可穿戴操作系统，但 [近期预测的苹果全新的圆形表盘设计专利](https://www.cnet.com/news/round-apple-watch-patent-granted/) 预示了一种新的可能性。同时也有可能出现 [一个更大规模的表盘商店](https://9to5mac.com/2018/04/14/watchos-4-3-1-suggests-future-support-for-third-party-watch-faces/)，或者更多的表盘定制化。否则，我们将看到一些关于继续扩展苹果手表的健康和健身功能的发布（通过 HealthKit 软件集）。
 
 ## TV OS、Audio OS 和 Siri：让苹果电视和 HomePod 更加智能
 

--- a/TODO1/wwdc-2018-rumors-ios-12-new-macbook-air-ipad-pro-homepod.md
+++ b/TODO1/wwdc-2018-rumors-ios-12-new-macbook-air-ipad-pro-homepod.md
@@ -1,4 +1,4 @@
-> * 原文地址：[WWDC 2018: All the rumors on iOS 12, iPad Pro, new MacBooks and more](https://www.cnet.com/news/wwdc-2018-rumors-ios-12-new-macbook-air-ipad-pro-homepod/)https://www.cnet.com/news/wwdc-2018-rumors-ios-12-new-macbook-air-ipad-pro-homepod/
+> * 原文地址：[WWDC 2018: All the rumors on iOS 12, iPad Pro, new MacBooks and more](https://www.cnet.com/news/wwdc-2018-rumors-ios-12-new-macbook-air-ipad-pro-homepod/)
 > * 原文作者：[JOHN FALCONE](https://www.cnet.com/profiles/jpfalcone/), [JUSTIN JAFFE](https://www.cnet.com/profiles/justin+jaffe/)
 > * 译文出自：[掘金翻译计划](https://github.com/xitu/gold-miner)
 > * 本文永久链接：[https://github.com/xitu/gold-miner/blob/master/TODO1/wwdc-2018-rumors-ios-12-new-macbook-air-ipad-pro-homepod.md](https://github.com/xitu/gold-miner/blob/master/TODO1/wwdc-2018-rumors-ios-12-new-macbook-air-ipad-pro-homepod.md)
@@ -11,7 +11,7 @@
 
 我们距离[苹果公司](/apple/)的下一个正式发布会只有2周的时间了，我们通常可以在发布会上一窥该公司的未来。
 
-苹果公司一年一度的[世界开发者大会](https://www.cnet.com/wwdc)提供了关于下一代操作系统和软件应用的线索和方向，它们为该公司的[iPhone](https://www.cnet.com/products/apple-iphone-x/review/)、[iPad](https://www.cnet.com/products/apple-ipad-2018-9-7-inch/review/)、Macs、手表、[HomePod](https://www.cnet.com/products/apple-homepod/review/)音响和 [苹果电视](https://www.cnet.com/products/apple-tv-4k/review/)提供动力。今年的发布会于6月4日至8日，在美国加州圣何塞市的McEnery Convention Center举行，同时也给第三方开发者们提供了一个和苹果管理层、工程师以及产品设计人员沟通交流的机会。
+苹果公司一年一度的[世界开发者大会](https://www.cnet.com/wwdc)提供了关于下一代操作系统和软件应用的线索和方向，它们为该公司的[iPhone](https://www.cnet.com/products/apple-iphone-x/review/)、[iPad](https://www.cnet.com/products/apple-ipad-2018-9-7-inch/review/)、Macs、手表、[HomePod](https://www.cnet.com/products/apple-homepod/review/)音响和[苹果电视](https://www.cnet.com/products/apple-tv-4k/review/)提供动力。今年的发布会于6月4日至8日，在美国加州圣何塞市的McEnery Convention Center举行，同时也给第三方开发者们提供了一个和苹果管理层、工程师以及产品设计人员沟通交流的机会。
 
 [WWDC](https://www.cnet.com/wwdc/)中极有可能揭露将在今年内实现的针对操作系统、应用、服务以及软件框架的更新升级。但是，苹果有时也会用来发布一些新的硬件。在我们进行更深层次的软件预计分析之前，我们先来探讨一下可能会发布哪些新的硬件。
 

--- a/TODO1/wwdc-2018-rumors-ios-12-new-macbook-air-ipad-pro-homepod.md
+++ b/TODO1/wwdc-2018-rumors-ios-12-new-macbook-air-ipad-pro-homepod.md
@@ -2,108 +2,108 @@
 > * 原文作者：[JOHN FALCONE](https://www.cnet.com/profiles/jpfalcone/), [JUSTIN JAFFE](https://www.cnet.com/profiles/justin+jaffe/)
 > * 译文出自：[掘金翻译计划](https://github.com/xitu/gold-miner)
 > * 本文永久链接：[https://github.com/xitu/gold-miner/blob/master/TODO1/wwdc-2018-rumors-ios-12-new-macbook-air-ipad-pro-homepod.md](https://github.com/xitu/gold-miner/blob/master/TODO1/wwdc-2018-rumors-ios-12-new-macbook-air-ipad-pro-homepod.md)
-> * 译者：
+> * 译者：[Dandy Xu](https://github.com/dandyxu)
 > * 校对者：
 
-# WWDC 2018: All the rumors on iOS 12, iPad Pro, new MacBooks and more
+# WWDC 2018：关于iOS 12、iPad Pro、新MacBooks或者更多产品的所有预测
 
-## What's going to happen when Tim Cook takes the stage in San Jose on June 4?
+## 当蒂姆库克(Tim Cook)在6月4日走进圣何塞(San Jose)的发布会现场时将会发生什么事情？(译者注：圣何塞(San Jose)是美国加州的第三大城市)
 
-We're just two weeks away from getting our next official glimpse of [Apple's](/apple/) future.
+我们距离[苹果公司](/apple/)的下一个正式发布会只有2周的时间了，我们通常可以在发布会上一窥该公司的未来。
 
-The company's annual [Worldwide Developers Conference](https://www.cnet.com/wwdc/) offers clues about the road ahead for the next operating systems and software applications that power Apple's [iPhones](/products/apple-iphone-x/review/), [iPads](/products/apple-ipad-2018-9-7-inch/review/), Macs, watches, [HomePod](/products/apple-homepod/review/) speakers and [Apple TV](/products/apple-tv-4k/review/) streamers. The show, which runs this year from June 4 to 8 at the McEnery Convention Center in San Jose, CA, will also give third-party developers the opportunity to mix it up with Apple executives, engineers and product designers.
+苹果公司一年一度的[世界开发者大会](https://www.cnet.com/wwdc)提供了关于下一代操作系统和软件应用的线索和方向，它们为该公司的[iPhones](/products/apple-iphone-x/review/)、[iPads](/products/apple-ipad-2018-9-7-inch/review/)、Macs、手表、[HomePod](/products/apple-homepod/review/)音响和 [苹果电视](/products/apple-tv-4k/review/)提供动力。今年的发布会于6月4日至8日，在美国加州圣何塞市的McEnery Convention Center举行，同时也给第三方开发者们提供了一个和苹果管理层、工程师以及产品设计人员沟通交流的机会。
 
-[WWDC](/wwdc/) is very much about unveiling upgrades to operating systems, apps, services and software frameworks that will hit later in the year. However, Apple sometimes uses the spotlight to launch new hardware, too. We'll tackle that possibility first, before offering a deeper dive into the more likely software expectations.
+[WWDC](/wwdc/)中极有可能揭露将在今年内实现的针对操作系统、应用、服务以及软件框架的更新升级。但是，苹果有时也会用来发布一些新的硬件。在我们进行更深层次的软件预计分析之前，我们先来探讨一下可能会发布哪些新的硬件。
 
-## Possible new iPad Pros, MacBooks and more
+## 可能会发布新的iPad Pros，MacBooks或者更多的硬件
 
-Don't expect to see new high-end iPhones or the new Mac Pro when Apple CEO Tim Cook takes the stage on June 4. The sequels to the [iPhone X](/products/apple-iphone-x/review/), [iPhone 8](/products/apple-iphone-8-review/) and [iPhone 8 Plus](/products/apple-iphone-8-plus/review/) are expected in September as usual, and Apple has already confirmed that the [new Mac Pro isn't coming until 2019](/news/the-new-mac-pro-is-coming-in-2019/). Likewise, the [HomePod](/products/apple-homepod/review/) speaker and [entry-level iPad](/products/apple-ipad-2018-9-7-inch/review/) are basically brand new, having just been released in February and March, respectively.
+当苹果公司CEO蒂姆库克(Tim Cook)在6月4日站在发布会舞台上时，不要期望能够看到新的高端iPhones或者新版本的Mac Pro。[iPhone X](/products/apple-iphone-x/review/)、[iPhone 8](/products/apple-iphone-8-review/)和[iPhone 8 Plus](/products/apple-iphone-8-plus/review/)通常在9月份发布，同时苹果也已经确认了[新的Mac Pro将于2019年发布](/news/the-new-mac-pro-is-coming-in-2019/)。同样的，[HomePod](/products/apple-homepod/review/)音响和[入门级别的iPad](/products/apple-ipad-2018-9-7-inch/review/)也分别于2月和3月刚刚全新发布。
 
-But here are four product categories that have a good shot of being refreshed in June:
+但这里有4个产品类别，极有可能在6月份进行发布：
 
-**MacBooks and iMacs:** Apple refreshed nearly its entire line of laptop and desktop computers at last year's WWDC. Now, a year later, moving the line to the newest [eighth-generation Intel processors](/news/kaby-lake-coffee-lake-and-beyond-what-we-know-about-the-next-intel-chips/) would be an easy -- albeit boring -- upgrade. Whether that would entail a larger design overhaul -- such as rethinking the [problematic butterfly keyboards](/news/apple-macbook-keyboard-issue-prompts-lawsuit/) and [still controversial Touch Bar features](/news/apple-macbook-pro-touch-problems-commentary/) on the [MacBook Pro laptops](/products/apple-macbook-pro-with-touch-bar-15-inch-2017/review/) -- would remain to be seen. The same goes for the MacBook Air, which has long been rumored to be getting a comeback model.
+**MacBooks and iMacs:** 在去年的WWDC中，苹果几乎将整条笔记本和台式机的产品线进行了更新。现在，一年过去了，将全部产品升级到最新的[第8代Intel处理器](/news/kaby-lake-coffee-lake-and-beyond-what-we-know-about-the-next-intel-chips/)，尽管有些枯燥，但确实是最简单的升级做法。但是否需要更大规模的设计检查 - 例如重新思考[蝴蝶键盘的问题](/news/apple-macbook-keyboard-issue-prompts-lawsuit/)和在[MacBook Pro笔记本](/products/apple-macbook-pro-with-touch-bar-15-inch-2017/review/)上[仍然存在争议的Touch Bar功能](/news/apple-macbook-pro-touch-problems-commentary/)，仍然有待观察。同样的问题也适用于MacBook Air，一直有预测说该系列将会迎来新的型号。
 
-Read: [2018 MacBook Air: All the rumors on specs, price and release date](/news/2018-macbook-air-all-the-rumors-on-specs-price-release-date/)
+阅读：[2018 MacBook Air：所有关于规格、价格以及发布时间的预测](/news/2018-macbook-air-all-the-rumors-on-specs-price-release-date/)
 
 ![ipad-pro-12-34](https://cnet1.cbsistatic.com/img/pLk32huKrWmXsXUmt-XHiJupsbM=/970x0/2017/07/17/33e09a24-eba2-4e4b-890e-0f6faa1da6e8/ipad-pro-12-34.jpg)
 
 Sarah Tew/CNET
 
-**iPad Pros:** Apple brought a keystone feature of the [iPad Pro](/products/apple-ipad-pro-10-5-inch-2017/review/) line -- compatibility with the Pencil stylus -- to the new [entry-level iPad](/products/apple-ipad-2018-9-7-inch/review/) that debuted in March. The conventional wisdom is that the pricier iPad Pro models can now be teed up for an iPhone X-style design overhaul: Ditching the home button and adding Face ID, perhaps.
+**iPad Pros:** 苹果刚刚在3月给[iPad Pro](/products/apple-ipad-pro-10-5-inch-2017/review/)产品线引入了一个重要的功能，就是让新的[入门级iPad](/products/apple-ipad-2018-9-7-inch/review/)首次可以兼容Pencil stylus。人们普遍认为这也许将使价格昂贵的iPad Pro能够也采用iPhone X风格的设计：去掉home键，同时添加Face ID。
 
-Read: [iPad Pro 2018: All the rumors on specs, price, release date](/news/ipad-pro-2018-all-the-rumors-on-specs-price-release-date/)
+阅读：[iPad Pro 2018：所有关于规格、价格以及发布时间的预测](/news/ipad-pro-2018-all-the-rumors-on-specs-price-release-date/)
 
-**iPhone SE 2:** As we said, the big iPhone upgrades are expected in the standard September time frame. But there are persistent rumors that the [iPhone SE](/products/apple-iphone-se-review/), the entry-level iPhone which debuted in March 2016, is due for an upgrade of some sort. Whether that's a full-screen iPhone X design (which seems improbable) or just a specs upgrade in the same body (much more likely) is unknown.
+**iPhone SE 2:** 如我们之前说过的，iPhone的大升级通常都在9月份。但一直有预测说[iPhone SE](/products/apple-iphone-se-review/)，首次在2016年3月亮相的入门级iPhone，应该进行某些部分的升级。是否采用全屏幕的iPhone X设计(看起来不太可能)或者只是基于现有模块的规格升级(更有可能)，这些都是未知的。
 
-Read: [iPhone SE 2: Rumored specs, price, release date](/news/iphone-se-2-launch-date-specs-price-release-date-rumors-notch/)
+阅读：[iPhone SE 2：预测的规格、价格、发布时间](/news/iphone-se-2-launch-date-specs-price-release-date-rumors-notch/)
 
-**Apple AirPower:** When Phil Schiller, Apple's senior vice president of worldwide marketing, introduced this multi-device charging pad alongside the iPhone X in September 2017, he said it was coming "next year." So while you can't say it's "late" until Jan. 1, 2019, one has to assume Apple would like to get this accessory on store shelves before the one-year anniversary of its announcement. WWDC would be a perfect opportunity to announce pricing and availability -- and maybe we could see that AirPower-compatible AirPods case, too.
+**Apple AirPower:** 当Phil Schiller，苹果公司的全球市场高级副总裁，在2017年9月介绍这个和iPhone X搭配使用的，多设备的充电设备时，他说这将在"明年"推出。所以，直到2019年的1月1日，你都不能说它推出“晚”了，有一种假设是苹果公司希望在这个产品发布一周年之前，将它放上货架出售。WWDC将会是一个绝佳的机会去宣布它的价格和发售日期 - 也许我们还能看到和AirPower兼容的AirPods收纳盒。
 
-Read: [AirPower: All we know about Apple's wireless charging pad](/news/apple-airpower-wireless-charger-everything-we-know/)
+阅读：[AirPower: 我们所知道的苹果无线充电板](/news/apple-airpower-wireless-charger-everything-we-know/)
 
 ![airpower-charging](https://cnet3.cbsistatic.com/img/ncNN2P2MqPIxuYdY7jRaGHHUkzM=/970x0/2017/09/12/02937a84-4f0a-4611-8af2-4a5764b95055/screen-shot-2017-09-12-at-2-44-50-pm.png)
 
-AirPower was announced back in September of 2017, but has yet to appear.
+AirPower早在2017年的9月份就发布了，但到现在还没有发售。
 
-Screenshot by Alexandra Able/CNET
+截图来自Alexandra Able/CNET
 
-**Other stuff we don't expect on June 4:** As for other Apple hardware, pretty much anything else would be a longshot. Don't expect new Apple Watches, Apple TV boxes, [second-gen AirPods](/news/apple-airpods-2-wireless-charging-things-we-expect/) or [mini HomePod speakers](/news/homepod-slow-sales-homepod-mini-homepod-price-cut/). And while Apple may spend more time talking up [AR Kit](/pictures/best-arkit-apps/) -- its software toolset for bringing augmented reality to iOS -- and [virtual reality on the Mac](/news/apple-bringing-vr-external-graphics-and-game-engines-to-mac/), definitely don't expect any hint of that [Apple AR/VR headset](/news/apple-is-working-on-an-ar-augmented-reality-vr-virtual-reality-headset-powered-by-a-wireless-wigig-hub/) that the company is apparently tinkering with behind closed doors -- that's expected closer to 2020, if at all.
+**其他我们不期望在6月4日出现的产品:** 对于其他的苹果硬件，恐怕它们都需要一个长期的过程。不要期望会看到新的苹果手表，苹果电视盒，[第二代的AirPods](/news/apple-airpods-2-wireless-charging-things-we-expect/)或者[小型HomePod音响](/news/homepod-slow-sales-homepod-mini-homepod-price-cut/)。也许苹果会花一些时间去提及[AR Kit](/pictures/best-arkit-apps/) - 它是一个软件工具集，将增强现实带进iOS - 同时[Mac里的虚拟现实](/news/apple-bringing-vr-external-graphics-and-game-engines-to-mac/)，但绝对不用期待任何关于[苹果AR/VR头戴式设备](/news/apple-is-working-on-an-ar-augmented-reality-vr-virtual-reality-headset-powered-by-a-wireless-wigig-hub/)，苹果公司显然在暗地里进行研发 - 但如果是的话，这些都需要直到2020年才能知晓。
 
-What you will see, however, is plenty of new software and operating systems for nearly everything mentioned above. Here's what to expect.
+你将看到的将是针对以上几乎所有硬件的大量新的软件以及操作系统。以下是可以期待的内容。
 
-## iOS 12: prioritizing quality over quantity
+## iOS 12：质量高于数量
 
-After grappling with a [persistent streak](/news/how-to-fix-the-ios-11-1-autocorrect-bug/) [of flaws](https://www.cnet.com/news/apple-updates-operating-systems-to-fix-app-crashing-bug/) [and](https://www.cnet.com/how-to/why-you-should-avoid-your-iphones-calculator/) [glitches](https://www.cnet.com/news/apple-slows-down-older-iphone-battery-issues/) that have besmirched the reputation of iOS 11 -- including [the controversial "feature" that intentionally slows down iPhones](/news/apple-slows-down-older-iphone-battery-issues/) -- Apple [is said to be focusing on quality over innovation](https://www.bloomberg.com/news/articles/2018-01-30/apple-is-said-to-push-back-some-key-iphone-software-features) with the forthcoming version of its mobile operating system, ostensibly called iOS 12\.
+在一系列[持续的]((/news/how-to-fix-the-ios-11-1-autocorrect-bug/))[缺陷](https://www.cnet.com/news/apple-updates-operating-systems-to-fix-app-crashing-bug/)[和](https://www.cnet.com/how-to/why-you-should-avoid-your-iphones-calculator/)[小故障](https://www.cnet.com/news/apple-slows-down-older-iphone-battery-issues/)后，这些问题都导致iOS11口碑不佳 - 包括[关于故意降低iPhones性能的有争议功能](/news/apple-slows-down-older-iphone-battery-issues/) - 苹果[称将会聚焦在质量而不是创新](https://www.bloomberg.com/news/articles/2018-01-30/apple-is-said-to-push-back-some-key-iphone-software-features)在它即将到来的移动操作系统中，也就是所谓的iOS 12。
 
-This may result in the postponement of some planned upgrades including a redesigned home screen, photography enhancements and multiplayer support for AR gaming, according to [Bloomberg](https://www.bloomberg.com/news/articles/2018-01-30/apple-is-said-to-push-back-some-key-iphone-software-features), which has been the primary source for the lion's share of published rumors to date.
+这也许将推迟一些计划中的升级，包括重新设计的主屏，摄像头的增强以及针对AR游戏的多媒体播放器的支持，该消息来自[彭博社](https://www.bloomberg.com/news/articles/2018-01-30/apple-is-said-to-push-back-some-key-iphone-software-features)，它也是目前为止所有这些预测的主要来源。
 
-[[iphone-8-rendering-armend.png](https://cnet2.cbsistatic.com/img/H0LiIaasuxLf5kdAoMYgFrmTEZA=/724x407/2018/02/28/909a855f-937f-4d63-920b-83e3fa456607/iphone-x2.jpg)](https://www.cnet.com/pictures/iphone-2018-most-wanted-features/)
+[![iphone-8-rendering-armend.png](https://cnet2.cbsistatic.com/img/H0LiIaasuxLf5kdAoMYgFrmTEZA=/724x407/2018/02/28/909a855f-937f-4d63-920b-83e3fa456607/iphone-x2.jpg)](https://www.cnet.com/pictures/iphone-2018-most-wanted-features/)
 
-iPhone 2018: Most-wanted features
+iPhone 2018：最需要的功能
 
-That's not to say that iOS 12 won't deliver some new treats. Japanese blog [Mac Otakara](http://www.macotakara.jp/blog/rumor/entry-34952.html) reports the update may feature a more polished version of Face ID that includes the ability to unlock a device in a horizontal landscape mode. And Bloomberg has reported that Apple plans to expand its lineup of [Animojis](/news/getting-started-with-the-iphone-x-animoji-apple/). And, of course, if Animojis (and Apple's [TrueDepth](/news/apple-face-id-truedepth-how-it-works/) camera technology) are coming to future versions of the iPad, that support will need to be added to the tablet side of the iOS software, too.
+这不代表着iOS 12不会发布一些新的功能。日本博客[Mac Otakara](http://www.macotakara.jp/blog/rumor/entry-34952.html)报道说一些更新将着重于改进Face ID，包括能够于水平景观模式解锁设备的能力。同时，彭博社也报道过苹果计划扩展它的[动态表情库](/news/getting-started-with-the-iphone-x-animoji-apple/)。同时，当然，如果动态表情（和苹果的[景深](/news/apple-face-id-truedepth-how-it-works/)摄像头技术）正在引入未来版本的iPad中，这些支持也将需要加入到iOS软件的平板系统中。
 
-## MacOS: Doubling down on security
+## MacOS: 双倍下注于安全
 
-It's not just iOS that's been buggy. In November 2017, [researchers discovered a colossal security flaw](/news/apple-flaw-allows-macos-high-sierra-logins-without-passwords/) in Apple's Mac operating system, allowing users to login to virtually any Mac laptop or desktop without a password. ([Here's how to prevent access if you haven't updated MacOS recently](https://support.apple.com/en-us/HT204012).) As such, we expect Apple to invest more time and energy than usual highlighting security and privacy at this year's WWDC.
+不仅仅是iOS有许多软件问题。在2017年11月，[研究人员已经发现了一个巨大的安全漏洞](/news/apple-flaw-allows-macos-high-sierra-logins-without-passwords/)，它位于苹果的Mac操作系统，允许用户能够在任何Mac笔记本或者台式机上虚拟登陆，并且不需要密码。([如果你近期没有更新MacOS，这里是如何防止此类访问的方法](https://support.apple.com/en-us/HT204012)) 诸如此类，我们期待苹果能够投入更多的时间和精力在今年的WWDC中。
 
 ![apple-watch-faces.jpg](https://cnet4.cbsistatic.com/img/JsfogWRVDuQhU5AF9zZFW3caio0=/970x0/2014/11/27/2a3d4179-935d-459a-9c19-25d6a3eee158/apple-watch-faces.jpg)
 
-Time for more faces on Apple Watch?
+现在到了给苹果手表添加更多表盘的时间？
 
-Screenshot by César Salza/CNET
+截图来自César Salza/CNET
 
-## WatchOS: expanding health and fitness functionality
+## WatchOS：扩展健康和健身功能
 
-Little is known about what Apple has up its sleeve with regard to its wristbound OS, but [the recent news about Apple's new round-display Watch patent](/news/round-apple-watch-patent-granted/) portends a new avenue of possibilities. There's also the chance of [an expanded watch face store](https://9to5mac.com/2018/04/14/watchos-4-3-1-suggests-future-support-for-third-party-watch-faces/), or more watch face customization. Otherwise, we expect to see some announcements related to the continuing expansion of the Apple Watch's health and fitness functionality (via the HealthKit software toolset).
+现在只有很少的一些信息关于苹果如何对待它的可穿戴操作系统，但[近期预测的苹果全新的圆形表盘设计专利](/news/round-apple-watch-patent-granted/)预示了一种新的可能性。同时也有可能出现[一个更大规模的表盘商店](https://9to5mac.com/2018/04/14/watchos-4-3-1-suggests-future-support-for-third-party-watch-faces/)，或者更多的表盘定制化。否则，我们将看到一些关于继续扩展苹果手表的健康和健身功能的发布(通过HealthKit软件集)。
 
-## TV OS, Audio OS and Siri: Making Apple TV and HomePod smarter
+## TV OS、Audio OS和Siri：让苹果电视和HomePod更加智能
 
-We already know that the [beta for tvOS 11.4](/news/airplay-2-multiroom-audio-apple-tv-homepod-ios-11-4-hands-on/) more tightly integrates Apple TV into the Home app, and offers compatibility with the AirPlay 2 multiroom speaker feature first unveiled at WWDC 2017\. That may mean more integration with HomeKit, Apple's [smart home](https://www.cnet.com/smart-home/) platform, is on deck for this year's WWDC. Maybe we'll hear more about games and the TV app on Apple's streamer, too.
+我们已经知道[tvOS 11.4的beta版本](/news/airplay-2-multiroom-audio-apple-tv-homepod-ios-11-4-hands-on/)将会更加紧密地结合苹果电视，集成到Home应用中，同时提供和首次于2017年WWDC揭露的AirPlay 2多房间音响功能的兼容性支持。这也许意味着更多和HomeKit的集成，苹果的[智能家居](https://www.cnet.com/smart-home/)平台，将在今年的WWDC中准备就绪。也许我们也将听到更多关于游戏和电视应用的消息。
 
 ![homepod-product-photos-12](https://cnet4.cbsistatic.com/img/KaRXiRMCYAkcqVm3q0radFmPjHg=/970x0/2018/02/04/d5f53fb7-49e8-4f7d-84e0-574c3992572c/homepod-product-photos-12.jpg)
 
 Tyler Lizenby/CNET
 
-iOS 11.4 will finally deliver that promised multiroom audio and stereo pairing for HomePod, too. But while that product's hardware is top-notch, its software remains seriously lacking. We're hoping Apple uses the one-year anniversary of the HomePod's WWDC debut to spell out specific improvements to its Audio OS operating system, so the speaker can rely less on a paired iPhone and become a more viable challenge to [Amazon's Echo](/news/amazon-echo-alexa-devices-everything-you-need-to-know/) and [Google's Home speaker systems](/news/everything-you-need-to-know-about-google-home/).
+iOS 11.4也将最终部署已经承诺过的多房间语音和立体声配对功能到HomePod中。但当一个产品的硬件是顶尖的，它的软件却严重缺乏。我们希望苹果能够借HomePod发布一周年的时机，宣布针对语音操作系统的特定改进。因此，音响能够减少对于iPhone的依赖，对[亚马逊的Echo](/news/amazon-echo-alexa-devices-everything-you-need-to-know/)和[谷歌的家庭音响系统](/news/everything-you-need-to-know-about-google-home/)构成明显的挑战。
 
-And while we're at it: Everyone agrees Siri needs a serious overhaul if Apple wants to go toe-to-toe with Alexa and Google Assistant.
+同时我们也关注：所有人都同意Siri需要一次严谨的重构，如果苹果依然希望和Alexa以及Google Assistant进行竞争的话。
 
-## What about 'Marzipan'?
+## 关于'Marzipan'？
 
-One of the biggest obsessions of Apple developers in recent months revolves around "Marzipan." That's the supposed code name of an initiative, first reported by [Bloomberg](https://www.bloomberg.com/news/articles/2017-12-20/apple-is-said-to-have-plan-to-combine-iphone-ipad-and-mac-apps) in January, to give users a "way to use a single set of apps that work equally well across its family of devices: iPhones, iPads and Macs."
+苹果开发者在最近几个月中最大的困扰之一就是关于“Marzipan”。这应该是初始版本的开发代号，首次由[彭博社](https://www.bloomberg.com/news/articles/2017-12-20/apple-is-said-to-have-plan-to-combine-iphone-ipad-and-mac-apps)在1月份报道，旨在为用户带来一种“使用一组能够在iPhones、iPads和Macs都运行良好的应用程序”的方式。
 
-While many assumed that meant an eventual world where [iOS apps could run on Macs](/news/apple-may-offer-combined-ios-and-mac-apps-next-year/) -- if not a unified iOS/MacOS operating system -- the truth may be less dramatic. According to [Apple pundit John Gruber](https://daringfireball.net/2018/04/scuttlebutt_regarding_ui_project), the Marzipan name is unknown to his sources. But he says that Apple is apparently working on a shared toolset which would allow iOS and Mac apps to be developed in a common environment, at least up to a point. That's a contrast to the current situation in which developers must design, engineer and distribute separate versions for each platform, which requires a lot of redundant work.
+当许多人都在假设这意味着最终[iOS应用可能运行在Macs](/news/apple-may-offer-combined-ios-and-mac-apps-next-year/)中 - 如果不是一个统一的iOS/MacOS操作系统 - 真相也许就不会那么戏剧性。根据[苹果权威专家John Gruber](https://daringfireball.net/2018/04/scuttlebutt_regarding_ui_project)，他对于Marzipan的名字一无所知。但他称苹果目前显然正在研究一种共享工具集，它能够将iOS和Mac的应用在一个通用的环境中同时开发，至少类似于以上消息。相反地，目前的情况是开发者必须要为每一个平台设计，开发和部署不同的版本，这导致了很多重复的工作。
 
-Gruber's story puts forth a less ambitious and certainly less dramatic narrative for a future collaboration of iOS and MacOS -- albeit one that sounds more practical for developers, as well as more technically feasible. However, he also points out that "it's a 2019 thing" -- meaning you shouldn't expect to hear any public disclosure of the plans at this year's WWDC.
+Gruber的说法揭露了一种更少野心，但同时更加现实的为iOS和MacOS服务的协作方式 - 虽然是一种听起来对开发者更实际的方式，但也在技术上更具可能性。但是，他还指出“这将是2019年的事情” - 意味着你应当不会在今年的WWDC中听到任何公开的披露。
 
-## See you on June 4
+## 让我们6月4日拭目以待
 
-CNET will have complete coverage of WWDC, including previews, live coverage of the event from San Jose and plenty of follow-up analysis, too. Stay tuned.
+CNET将全程报道WWDC，包括预览，圣何塞的发布会现场直播以及许多后续的更近报道。保持关注
 
-[iPhone 2018](/news/iphone-2018-iphone-x-plus-launch-date-specs-price-release-date-rumors/): All the rumors on specs, features and release date
+[iPhone 2018](/news/iphone-2018-iphone-x-plus-launch-date-specs-price-release-date-rumors/)：所有关于规格、功能和发布时间的预测
 
-[Google I/O 2018](/news/duplex-android-p-and-assistant-everything-important-from-google-io/): Everything important that Google announced
+[Google I/O 2018](/news/duplex-android-p-and-assistant-everything-important-from-google-io/)：所有谷歌宣布的重要事宜
 
 > 如果发现译文存在错误或其他需要改进的地方，欢迎到 [掘金翻译计划](https://github.com/xitu/gold-miner) 对译文进行修改并 PR，也可获得相应奖励积分。文章开头的 **本文永久链接** 即为本文在 GitHub 上的 MarkDown 链接。
 

--- a/TODO1/wwdc-2018-rumors-ios-12-new-macbook-air-ipad-pro-homepod.md
+++ b/TODO1/wwdc-2018-rumors-ios-12-new-macbook-air-ipad-pro-homepod.md
@@ -79,7 +79,7 @@ iPhone 2018：最需要的功能
 
 ## TV OS、Audio OS和Siri：让苹果电视和HomePod更加智能
 
-我们已经知道[tvOS 11.4的beta版本](/news/airplay-2-multiroom-audio-apple-tv-homepod-ios-11-4-hands-on/)将会更加紧密地结合苹果电视，集成到Home应用中，同时提供和首次于2017年WWDC发布的AirPlay 2多房间音响功能的兼容性支持。这也许意味着更多和HomeKit的集成，苹果的[智能家居](https://www.cnet.com/smart-home/)平台，将在今年的WWDC中准备就绪。也许我们也将听到更多关于游戏和电视应用的消息。
+我们已经知道[tvOS 11.4的beta版本](https://www.cnet.com/news/airplay-2-multiroom-audio-apple-tv-homepod-ios-11-4-hands-on/)将会更加紧密地结合苹果电视，集成到Home应用中，同时提供和首次于2017年WWDC发布的AirPlay 2多房间音响功能的兼容性支持。这也许意味着更多和HomeKit的集成，苹果的[智能家居](https://www.cnet.com/smart-home/)平台，将在今年的WWDC中准备就绪。也许我们也将听到更多关于游戏和电视应用的消息。
 
 ![homepod-product-photos-12](https://cnet4.cbsistatic.com/img/KaRXiRMCYAkcqVm3q0radFmPjHg=/970x0/2018/02/04/d5f53fb7-49e8-4f7d-84e0-574c3992572c/homepod-product-photos-12.jpg)
 
@@ -101,9 +101,9 @@ Gruber的说法揭露了一种更少野心，但同时更加现实的为iOS和Ma
 
 CNET将全程报道WWDC，包括预览，圣何塞的发布会现场直播以及许多后续的更近报道。保持关注。
 
-[iPhone 2018](/news/iphone-2018-iphone-x-plus-launch-date-specs-price-release-date-rumors/)：所有关于规格、功能和发布时间的预测
+[iPhone 2018](https://www.cnet.com/news/iphone-2018-iphone-x-plus-launch-date-specs-price-release-date-rumors/)：所有关于规格、功能和发布时间的预测
 
-[Google I/O 2018](/news/duplex-android-p-and-assistant-everything-important-from-google-io/)：所有谷歌宣布的重要事宜
+[Google I/O 2018](https://www.cnet.com/news/duplex-android-p-and-assistant-everything-important-from-google-io/)：所有谷歌宣布的重要事宜
 
 > 如果发现译文存在错误或其他需要改进的地方，欢迎到 [掘金翻译计划](https://github.com/xitu/gold-miner) 对译文进行修改并 PR，也可获得相应奖励积分。文章开头的 **本文永久链接** 即为本文在 GitHub 上的 MarkDown 链接。
 

--- a/TODO1/wwdc-2018-rumors-ios-12-new-macbook-air-ipad-pro-homepod.md
+++ b/TODO1/wwdc-2018-rumors-ios-12-new-macbook-air-ipad-pro-homepod.md
@@ -9,7 +9,7 @@
 
 ## 当蒂姆库克(Tim Cook)在6月4日走进圣何塞(San Jose)的发布会现场时将会发生什么事情？(译者注：圣何塞(San Jose)是美国加州的第三大城市)
 
-我们距离[苹果公司](/apple/)的下一个正式发布会只有2周的时间了，我们通常可以在发布会上一窥该公司的未来。
+我们距离[苹果公司](https://www.cnet.com/apple/)的下一个正式发布会只有2周的时间了，我们通常可以在发布会上一窥该公司的未来。
 
 苹果公司一年一度的[世界开发者大会](https://www.cnet.com/wwdc)提供了关于下一代操作系统和软件应用的线索和方向，它们为该公司的[iPhone](https://www.cnet.com/products/apple-iphone-x/review/)、[iPad](https://www.cnet.com/products/apple-ipad-2018-9-7-inch/review/)、Macs、手表、[HomePod](https://www.cnet.com/products/apple-homepod/review/)音响和[苹果电视](https://www.cnet.com/products/apple-tv-4k/review/)提供动力。今年的发布会于6月4日至8日，在美国加州圣何塞市的McEnery Convention Center举行，同时也给第三方开发者们提供了一个和苹果管理层、工程师以及产品设计人员沟通交流的机会。
 
@@ -29,7 +29,7 @@
 
 Sarah Tew/CNET
 
-**iPad Pros:** 苹果刚刚在3月给[iPad Pro](/products/apple-ipad-pro-10-5-inch-2017/review/)产品线引入了一个重要的功能，就是让新的[入门级iPad](https://www.cnet.com/products/apple-ipad-2018-9-7-inch/review/)兼容手写笔。人们认为这种举措将使价格更高的iPad Pro可以向iPhone X的风格迈进：去掉home键，同时添加Face ID。
+**iPad Pros:** 苹果刚刚在3月给[iPad Pro](https://www.cnet.com/products/apple-ipad-pro-10-5-inch-2017/review/)产品线引入了一个重要的功能，就是让新的[入门级iPad](https://www.cnet.com/products/apple-ipad-2018-9-7-inch/review/)兼容手写笔。人们认为这种举措将使价格更高的iPad Pro可以向iPhone X的风格迈进：去掉home键，同时添加Face ID。
 
 阅读：[iPad Pro 2018：所有关于规格、价格以及发布时间的预测](https://www.cnet.com/news/ipad-pro-2018-all-the-rumors-on-specs-price-release-date/)
 
@@ -53,7 +53,7 @@ AirPower早在2017年的9月份就发布了，但到现在还没有发售。
 
 ## iOS 12：质量高于数量
 
-在经历了一系列[持续的]((/news/how-to-fix-the-ios-11-1-autocorrect-bug/))[缺陷](https://www.cnet.com/news/apple-updates-operating-systems-to-fix-app-crashing-bug/)[和](https://www.cnet.com/how-to/why-you-should-avoid-your-iphones-calculator/)[小故障](https://www.cnet.com/news/apple-slows-down-older-iphone-battery-issues/)后，这些问题都导致iOS11口碑不佳 - 包括[关于故意降低iPhones性能的有争议功能](https://www.cnet.com/news/apple-slows-down-older-iphone-battery-issues/) - 苹果[称将会把质量放在比创新更重要的位置](https://www.bloomberg.com/news/articles/2018-01-30/apple-is-said-to-push-back-some-key-iphone-software-features)在它即将到来的移动操作系统中，也就是所谓的iOS 12。
+在经历了一系列[持续的](https://www.cnet.com/news/how-to-fix-the-ios-11-1-autocorrect-bug/)[缺陷](https://www.cnet.com/news/apple-updates-operating-systems-to-fix-app-crashing-bug/)[和](https://www.cnet.com/how-to/why-you-should-avoid-your-iphones-calculator/)[小故障](https://www.cnet.com/news/apple-slows-down-older-iphone-battery-issues/)后，这些问题都导致iOS11口碑不佳 - 包括[关于故意降低iPhones性能的有争议功能](https://www.cnet.com/news/apple-slows-down-older-iphone-battery-issues/) - 苹果[称将会把质量放在比创新更重要的位置](https://www.bloomberg.com/news/articles/2018-01-30/apple-is-said-to-push-back-some-key-iphone-software-features)在它即将到来的移动操作系统中，也就是所谓的iOS 12。
 
 这也许将推迟一些计划中的升级，包括重新设计的主屏，摄像头的增强以及针对AR游戏的多媒体播放器的支持，该消息来自[彭博社](https://www.bloomberg.com/news/articles/2018-01-30/apple-is-said-to-push-back-some-key-iphone-software-features)，它也是目前为止所有这些预测的主要来源。
 


### PR DESCRIPTION
WWDC 2018：关于iOS 12、iPad Pro、新MacBooks或者更多产品的所有预测

译文翻译完成，resolve #3873
