### PR TITLE
Android 数据绑定库  — 从可观察域到 LiveData 仅需两步

### DIFF
--- a/TODO1/android-data-binding-library-from-observable-fields-to-livedata-in-two-steps.md
+++ b/TODO1/android-data-binding-library-from-observable-fields-to-livedata-in-two-steps.md
@@ -3,7 +3,6 @@
 > * 译文出自：[掘金翻译计划](https://github.com/xitu/gold-miner)
 > * 本文永久链接：[https://github.com/xitu/gold-miner/blob/master/TODO1/android-data-binding-library-from-observable-fields-to-livedata-in-two-steps.md](https://github.com/xitu/gold-miner/blob/master/TODO1/android-data-binding-library-from-observable-fields-to-livedata-in-two-steps.md)
 > * 译者：[Rickon](https://github.com/gs666)
-> * 校对者：
 
 # Android 数据绑定库 — 从可观察域到 LiveData 仅需两步
 
@@ -13,7 +12,7 @@
 
 **默认情况下**，普通基元和字符串是**不**可被观察的，因此如果在数据绑定布局中使用它们，则在创建绑定时将使用它们的值，但对它们的后续更改会被忽略。
 
-为了使对象可被观察，我们的[数据绑定库](https://developer.android.com/topic/libraries/data-binding/)中包含了一系列可被观察的类：`ObservableBoolean` , `ObservableInt`,`ObservableDouble`和范型：`ObservableField<T>`。从现在开始，我们称这些为**可观察域**。
+为了使对象可被观察，我们的[数据绑定库](https://developer.android.com/topic/libraries/data-binding/)中包含了一系列可被观察的类：`ObservableBoolean`、`ObservableInt`、`ObservableDouble` 和范型：`ObservableField<T>`。从现在开始，我们称这些为**可观察域**。
 
 几年后，作为第一波[架构组件](https://developer.android.com/topic/libraries/architecture)的一部分，我们发布了 [**LiveData**](https://developer.android.com/topic/libraries/architecture/livedata)，这**又**是一个可被观察的。这是与数据绑定兼容的候选，因此我们添加了此功能。
 
@@ -23,8 +22,7 @@
 
 ## 第一步：使用 LiveData 代替可观察域
 
-如果你直接在数据绑定布局中使用可观察域，只需使用`LiveData<Something>`替换`ObservableSomething` (或`ObservableField<Something>`)
-。
+如果你直接在数据绑定布局中使用可观察域，只需使用 `LiveData<Something>` 替换 `ObservableSomething`（或 `ObservableField<Something>`）。
 
 修改前：
 
@@ -62,7 +60,7 @@
 
 ```
 
-或者，如果你从 [ViewModel](https://developer.android.com/topic/libraries/architecture/viewmodel)（首选方法）或一个 presenter 层或控制器暴露可观察对象，则无需更改布局。只需在 ViewModel 中用`LiveData`替换那些 `ObservableField`。
+或者，如果你从 [ViewModel](https://developer.android.com/topic/libraries/architecture/viewmodel)（首选方法）或一个 presenter 层或控制器暴露可观察对象，则无需更改布局。只需在 ViewModel 中用 `LiveData` 替换那些 `ObservableField`。
 
 修改前：
 
@@ -86,7 +84,7 @@ class MyViewModel : ViewModel() {
 
 ## 第二步：设置 LiveData 的生命周期所有者
 
-绑定类有一个名为`setLifecycleOwner`的方法，在从数据绑定布局中观察 LiveData 时必须调用该方法。
+绑定类有一个名为 `setLifecycleOwner` 的方法，在从数据绑定布局中观察 LiveData 时必须调用该方法。
 
 修改前：
 

--- a/TODO1/android-data-binding-library-from-observable-fields-to-livedata-in-two-steps.md
+++ b/TODO1/android-data-binding-library-from-observable-fields-to-livedata-in-two-steps.md
@@ -2,30 +2,31 @@
 > * 原文作者：[Jose Alcérreca](https://medium.com/@JoseAlcerreca)
 > * 译文出自：[掘金翻译计划](https://github.com/xitu/gold-miner)
 > * 本文永久链接：[https://github.com/xitu/gold-miner/blob/master/TODO1/android-data-binding-library-from-observable-fields-to-livedata-in-two-steps.md](https://github.com/xitu/gold-miner/blob/master/TODO1/android-data-binding-library-from-observable-fields-to-livedata-in-two-steps.md)
-> * 译者：
+> * 译者：[Rickon](https://github.com/gs666)
 > * 校对者：
 
-# Android Data Binding Library — From Observable Fields to LiveData in two steps
+# Android 数据绑定库 — 从可观察域到 LiveData 仅需两步
 
 ![Illustration by [Virginia Poltrack](https://twitter.com/vpoltrack)](https://cdn-images-1.medium.com/max/8418/1*QhbnhjTMT9gTIP36Lo7-mQ.png)
 
-One of the most important features of Data Binding is [**observability**](https://developer.android.com/topic/libraries/data-binding/observability). It allows you to bind data and UI elements so that when the data changes, the pertinent elements are updated on screen.
+数据绑定最重要的特性之一是[**可观察性**](https://developer.android.com/topic/libraries/data-binding/observability)。你可以用它绑定数据和 UI 元素，以便在数据更改时，相关元素在屏幕上更新。
 
-Plain primitives and Strings are **not** observable **by default** so if you use them in your Data Binding layouts, their values will be used when the binding is created but subsequent changes to them will be ignored.
+**默认情况下**，普通基元和字符串是**不**可被观察的，因此如果在数据绑定布局中使用它们，则在创建绑定时将使用它们的值，但对它们的后续更改会被忽略。
 
-To make objects observable, we included in the [Data Binding Library](https://developer.android.com/topic/libraries/data-binding/) a series of observable classes: `ObservableBoolean` , `ObservableInt`, `ObservableDouble`… and the generic , `ObservableField<T>`. We’ll call these **Observable Fields** from now on.
+为了使对象可被观察，我们的[数据绑定库](https://developer.android.com/topic/libraries/data-binding/)中包含了一系列可被观察的类：`ObservableBoolean` , `ObservableInt`,`ObservableDouble`和范型：`ObservableField<T>`。从现在开始，我们称这些为**可观察域**。
 
-Some years later, as part of the first wave of [Architecture Components](https://developer.android.com/topic/libraries/architecture), we released [**LiveData**](https://developer.android.com/topic/libraries/architecture/livedata), which is **another** observable. It was an obvious candidate to be compatible with Data Binding, so we added this capability.
+几年后，作为第一波[架构组件](https://developer.android.com/topic/libraries/architecture)的一部分，我们发布了 [**LiveData**](https://developer.android.com/topic/libraries/architecture/livedata)，这**又**是一个可被观察的。这是与数据绑定兼容的候选，因此我们添加了此功能。
 
-[LiveData](https://developer.android.com/topic/libraries/architecture/livedata) is lifecycle-aware but this is not a huge advantage with respect to Observable Fields because Data Binding already checks when the view is active. However, **LiveData supports [Transformations](https://developer.android.com/reference/android/arch/lifecycle/Transformations), and many Architecture Components, like [Room](https://developer.android.com/topic/libraries/architecture/room) and [WorkManager](https://developer.android.com/reference/androidx/work/WorkManager), support LiveData**.
+[LiveData](https://developer.android.com/topic/libraries/architecture/livedata) 是可以感知生命周期的，对于可观察域而言，这并不是一个很大的优势，因为数据绑定库已经检查了视图何时处于活动状态。但是，**LiveData 支持 [Transformations](https://developer.android.com/reference/android/arch/lifecycle/Transformations) 和很多架构组件，比如 [Room](https://developer.android.com/topic/libraries/architecture/room) 和 [WorkManager](https://developer.android.com/reference/androidx/work/WorkManager)。**
 
-**For these reasons, it’s recommended to migrate to LiveData.** You only need two simple steps to do so.
+**出于这些原因，建议你迁移到 LiveData。**你只需要两步即可完成。
 
-## Step 1: Replace Observable Fields with LiveData
+## 第一步：使用 LiveData 代替可观察域
 
-If you are using Observable Fields directly in your data binding layout, simply replace `ObservableSomething` (or `ObservableField<Something>`) with `LiveData<Something>`.
+如果你直接在数据绑定布局中使用可观察域，只需使用`LiveData<Something>`替换`ObservableSomething` (或`ObservableField<Something>`)
+。
 
-Before:
+修改前：
 
 ```XML
 <data>
@@ -44,7 +45,7 @@ Before:
 
 > **Remember that `%lt;` is not a typo. You have to escape the `<` character inside XML layouts.**
 
-After:
+修改后：
 
 ```XML
 <data>
@@ -61,9 +62,9 @@ After:
 
 ```
 
-Alternatively, if you’re exposing observables from a [ViewModel](https://developer.android.com/topic/libraries/architecture/viewmodel) (the preferred approach) or a presenter or controller, you don’t need to change your layout. Just replace those `ObservableField`s with `LiveData` in the ViewModel.
+或者，如果你从 [ViewModel](https://developer.android.com/topic/libraries/architecture/viewmodel)（首选方法）或一个 presenter 层或控制器暴露可观察对象，则无需更改布局。只需在 ViewModel 中用`LiveData`替换那些 `ObservableField`。
 
-Before:
+修改前：
 
 ```Kotlin
 class MyViewModel : ViewModel() {
@@ -72,7 +73,7 @@ class MyViewModel : ViewModel() {
 
 ```
 
-After:
+修改后：
 
 ```Kotlin
 class MyViewModel : ViewModel() {
@@ -83,11 +84,11 @@ class MyViewModel : ViewModel() {
 
 ```
 
-## Step 2 — Set the lifecycle owner for the LiveData
+## 第二步：设置 LiveData 的生命周期所有者
 
-Binding classes have a method called `setLifecycleOwner` that must be called when observing LiveData from a data binding layout.
+绑定类有一个名为`setLifecycleOwner`的方法，在从数据绑定布局中观察 LiveData 时必须调用该方法。
 
-Before:
+修改前：
 
 ```Kotlin
 val binding = DataBindingUtil.setContentView<TheGeneratedBinding>(
@@ -98,7 +99,7 @@ val binding = DataBindingUtil.setContentView<TheGeneratedBinding>(
 binding.name = myLiveData // or myViewModel
 ```
 
-After:
+修改后：
 
 ```Kotlin
 val binding = DataBindingUtil.setContentView<TheGeneratedBinding>(
@@ -112,11 +113,11 @@ binding.name = myLiveData // or myViewModel
 
 ```
 
-> **Note: If you’re setting the content for a fragment, it is recommended to use `fragment.viewLifecycleOwner` (instead of the fragment’s lifecycle) to deal with potential detached fragments.**
+> 注意：如果要设置 fragment 的内容，建议使用 `fragment.viewLifecycleOwner`（而不是 fragment 的生命周期）来处理潜在的分离的 fragments。
 
 ---
 
-Now you can use your [LiveData](https://developer.android.com/topic/libraries/architecture/livedata) objects with [Transformations](https://developer.android.com/reference/android/arch/lifecycle/Transformations) and [MediatorLiveData](https://developer.android.com/reference/android/arch/lifecycle/MediatorLiveData). If you’re not familiar with these features, check out this [recording of “Fun with LiveData”, from the Android Dev Summit 2018](https://www.youtube.com/watch?v=2rO4r-JOQtA).
+现在你可以使用你的带有 [Transformations](https://developer.android.com/reference/android/arch/lifecycle/Transformations) 和 [MediatorLiveData](https://developer.android.com/reference/android/arch/lifecycle/MediatorLiveData) 的 [LiveData](https://developer.android.com/topic/libraries/architecture/livedata) 对象。如果你不熟悉这些功能，可以参阅 [“Fun with LiveData” 录像，来自 2018 Android 开发者大会](https://www.youtube.com/watch?v=2rO4r-JOQtA)。
 
 > 如果发现译文存在错误或其他需要改进的地方，欢迎到 [掘金翻译计划](https://github.com/xitu/gold-miner) 对译文进行修改并 PR，也可获得相应奖励积分。文章开头的 **本文永久链接** 即为本文在 GitHub 上的 MarkDown 链接。
 


### PR DESCRIPTION
Android 数据绑定库 — 从可观察域到 LiveData 仅需两步

译文翻译完成，resolve #5953 
